### PR TITLE
Feature: parallel tasks inherit state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# threadbare
+
+A partial replacement for the Fabric 1.x `api` module.

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 set -e
-PYTHONPATH=threadbare/ python -m pytest tests/ -v
+source venv/bin/activate
+PYTHONPATH=threadbare/ python -m pytest tests/ -vv

--- a/tests/test_threadbare.py
+++ b/tests/test_threadbare.py
@@ -63,3 +63,31 @@ def test_settings_nested_closure():
     with enclosed(foo='bar'):
         with enclosed(baz='bop') as env2:
             assert env == env2 == {'foo':'bar','baz':'bop'}
+    assert env == {}
+
+# 
+
+def test_parallel_wrapper():
+    env = {}
+    def fn():
+        pass
+    wrapped_func = threadbare.parallel(env, fn)
+    assert hasattr(wrapped_func, 'parallel')
+    assert wrapped_func.parallel
+    assert hasattr(wrapped_func, 'pool_size')
+
+def test_execute():
+    env = {}
+    def fn():
+        return "hello, world"
+    expected = ["hello, world"]
+    assert expected == threadbare.execute(env, fn)
+
+def test_execute_many():
+    env = {}
+    def fn():
+        return "foo"
+    pool_size = 10
+    parallel_fn = threadbare.parallel(env, fn, pool_size=pool_size)
+    expected = ["foo"] * pool_size
+    assert expected == threadbare.execute(env, parallel_fn)

--- a/tests/test_threadbare.py
+++ b/tests/test_threadbare.py
@@ -37,6 +37,14 @@ def test_overridden_state():
         assert env == {'foo': 'baz'}
     assert env == {'foo': 'bar'}
 
+def test_deleted_state():
+    env = {'foo': 'bar'}
+    with settings(env) as newenv:
+        del env['foo']
+        assert env == {}
+    # `settings` is nothing more than a fancy wrapper around the original reference and is NOT a copy
+    assert env == {} # still empty
+
 def test_nested_state_initial_state():
     "state is returned to initial conditions"
     env = {'foo': 'bar'}

--- a/tests/test_threadbare.py
+++ b/tests/test_threadbare.py
@@ -153,11 +153,13 @@ def test_execute_many_parallel_no_params():
 def test_execute_many_parallel_with_params():
     def fn():
         with settings() as env:
-            return env['mykey']
+            return env
     env = {'parent': 'environment'}
     parallel_fn = threadbare.parallel(fn)
-    expected = ["foo", "bar", "baz"] # todo: failing, results are unordered
-    assert expected == threadbare.execute(env, parallel_fn, param_key='mykey', param_values=["foo", "bar", "baz"])
+    expected = [{'parent': 'environment', "mykey": 1},
+                {'parent': 'environment', "mykey": 2},
+                {'parent': 'environment', "mykey": 3}]
+    assert expected == threadbare.execute(env, parallel_fn, param_key='mykey', param_values=[1, 2, 3])
 
 def test_parallel_terminate():
     "when a process is terminated, ensure internal state is what we expect it to be"

--- a/tests/test_threadbare.py
+++ b/tests/test_threadbare.py
@@ -83,11 +83,26 @@ def test_execute():
     expected = ["hello, world"]
     assert expected == threadbare.execute(env, fn)
 
-def test_execute_many():
+def test_execute_many_serial():
     env = {}
     def fn():
         return "foo"
-    pool_size = 10
+    expected = ["foo"]
+    assert expected == threadbare.execute(env, fn)
+
+def test_execute_many_serial_params():
+    def fn():
+        with settings() as env:
+            return "foo" + str(env['key'])
+    expected = ["foobar", "foobaz", "foobop"]
+    local_env = None # emulates Fabric's global `_env` dictionary, but less than ideal
+    assert expected == threadbare.execute(local_env, fn, param_key="key", param_values=["bar", "baz", "bop"])
+
+def test_execute_many_parallel():
+    env = {}
+    def fn():
+        return "foo"
+    pool_size = 3
     parallel_fn = threadbare.parallel(env, fn, pool_size=pool_size)
     expected = ["foo"] * pool_size
     assert expected == threadbare.execute(env, parallel_fn)

--- a/tests/test_threadbare.py
+++ b/tests/test_threadbare.py
@@ -161,6 +161,27 @@ def test_execute_many_parallel_with_params():
                 {'parent': 'environment', "mykey": 3}]
     assert expected == threadbare.execute(env, parallel_fn, param_key='mykey', param_values=[1, 2, 3])
 
+def test_execute_many_parallel_raw_results():
+    def fn():
+        with settings() as env:
+            return env
+    env = {'parent': 'environment'}
+    parallel_fn = threadbare.parallel(fn)
+    param_key = 'mykey'
+    param_values = [1, 2, 3]
+    expected = [
+        {'pid': 28000, 'name': 'process--1', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parent': 'environment', 'mykey': 1}},
+        {'pid': 28000, 'name': 'process--2', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parent': 'environment', 'mykey': 2}},
+        {'pid': 28000, 'name': 'process--3', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parent': 'environment', 'mykey': 3}}]
+    results = threadbare._parallel_execution(env, parallel_fn, param_key, param_values)
+
+    def update(d, k, v):
+        d[k] = v
+        return d
+
+    results = [update(result, 'pid', 28000) for result in expected]
+    assert expected == results
+
 def test_parallel_terminate():
     "when a process is terminated, ensure internal state is what we expect it to be"
     def fn():

--- a/tests/test_threadbare.py
+++ b/tests/test_threadbare.py
@@ -111,9 +111,8 @@ def test_execute_many_parallel_no_params():
 def test_execute_many_parallel_with_params():
     def fn():
         with settings() as env:
-            print('env:',env)
             return env['mykey']
     env = {'parent': 'environment'}
     parallel_fn = threadbare.parallel(env, fn)
     expected = ["foo", "bar", "baz"] # todo: failing, results are unordered
-    assert expected == threadbare.execute(env, parallel_fn, param_key='mykey', param_values=["bar", "baz", "bop"])
+    assert expected == threadbare.execute(env, parallel_fn, param_key='mykey', param_values=["foo", "bar", "baz"])

--- a/tests/test_threadbare.py
+++ b/tests/test_threadbare.py
@@ -218,9 +218,8 @@ def test_execute_many_parallel():
 def test_execute_many_parallel_with_params():
     "`parallel` will wrap a given function and run it `pool_size` times in parallel, but is ignored when `execute` is given a list of values"
     def fn():
-        with settings() as env:
-            return env
-    env = {'parent': 'environment'}
+        with settings() as local_env:
+            return local_env
     parallel_fn = threadbare.parallel(fn, pool_size=1)
     param_key = 'mykey'
     param_values = [1,2,3]
@@ -228,7 +227,9 @@ def test_execute_many_parallel_with_params():
     expected = [{'parent': 'environment', "mykey": 1},
                 {'parent': 'environment', "mykey": 2},
                 {'parent': 'environment', "mykey": 3}]
-    assert expected == threadbare.execute(env, parallel_fn, param_key, param_values)
+
+    with settings(parent='environment') as env:
+        assert expected == threadbare.execute(env, parallel_fn, param_key, param_values)
 
 def test_execute_many_parallel_raw_results():
     "calling `_parallel_execution` directly provides access to the state of the processes"

--- a/tests/test_threadbare.py
+++ b/tests/test_threadbare.py
@@ -1,3 +1,4 @@
+import pytest
 import time
 from functools import partial
 import threadbare
@@ -106,6 +107,39 @@ def test_execute_many_serial_with_params():
     expected = ["foobar", "foobaz", "foobop"]
     local_env = None # use global env :(
     assert expected == threadbare.execute(local_env, fn, param_key="mykey", param_values=["bar", "baz", "bop"])
+
+def test_execute_with_missing():
+    def fn():
+        return
+    local_env = {}
+
+    with pytest.raises(ValueError):
+        threadbare.execute(local_env, fn, param_key='good_key', param_values=None)
+
+    with pytest.raises(ValueError):
+        threadbare.execute(local_env, fn, param_values=['good', 'values'])
+
+def test_execute_with_bad_param_key():
+    "`param_key` values must be strings"
+    def fn():
+        return
+    local_env = {}
+    cases = [None, [], {}, (), 1, lambda x: x]
+    for bad_param_key in cases:
+        print('testing',bad_param_key)
+        with pytest.raises(ValueError):
+            threadbare.execute(local_env, fn, param_key=bad_param_key, param_values=["foo"])
+
+def test_execute_with_bad_param_values():
+    "`param_values` must be a list, tuple or set of values"
+    def fn():
+        return
+    local_env = {}
+    cases = [None, 1, "", {}, lambda x: x]
+    for bad_param_values in cases:
+        print('testing',type(bad_param_values))
+        with pytest.raises(ValueError):
+            threadbare.execute(local_env, fn, param_key='mykey', param_values=bad_param_values)
 
 def test_execute_many_parallel_no_params():
     env = {}

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -1,4 +1,7 @@
+import uuid
 import contextlib
+from multiprocessing import Process, Queue
+import os, time
 
 ENV = {}
 
@@ -6,6 +9,8 @@ ENV = {}
 def settings(state=None, **kwargs):
     if state == None:
         state = ENV
+    if not isinstance(state, dict):
+        raise TypeError("state map must be a dictionary-like object, not %r" % type(state))
     original = {}
     for key, val in kwargs.items():
         if key in state:
@@ -19,3 +24,95 @@ def settings(state=None, **kwargs):
                 state[key] = original[key]
             else:
                 del state[key]
+
+def parallel(env, func, pool_size=None):
+    """Forces the wrapped function to run in parallel, instead of sequentially.
+    This is an opportunity for pre/process work prior to calling a function in parallel."""
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/decorators.py#L164-L194
+
+    def inner(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    inner.parallel = True # `func` *must* be forced to run in parallel to main process
+    inner.pool_size = pool_size if pool_size else None # when None, executor decides how many instances of `func` to execute
+    
+    return inner
+
+def _execute(env, func, name, queue):
+    result = func()
+    queue.put({'name': name, 'result': result})
+    return result
+
+
+def unique_id():
+    return str(uuid.uuid4())
+
+def execute(env, func):
+    """inspects a given function and then executes it either serially or in another process using Python's `multiprocessing` module.
+    blocks until all processes have completed or timeout is reached
+    """
+
+    # in Fabric, `execute` is a guard-type function that ensures the function and the function's environment is correct
+    # before passing it to `_execute` that does the actual magic.
+    # `execute`: https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L372-L401
+    # `_execute`: https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L213-L277
+
+    # the custom 'JobQueue' adds complexity but can be avoided (I hope):
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/job_queue.py
+
+    q = Queue()
+    kwargs = {
+        'env': env,
+        'func': func,
+        #'name': None, # a name is assigned on process start
+        'queue': q,
+    }
+    pool_size = getattr(func, 'pool_size', 1)
+    pool = []
+    for n in range(0, pool_size):
+        kwargs['name'] = unique_id()
+        p = Process(name=kwargs['name'], target=_execute, kwargs=kwargs)
+        p.start()
+        pool.append(p)
+        
+    def status(running_p):
+        # https://docs.python.org/2/library/multiprocessing.html#process-and-exceptions
+        result = {'pid': running_p.pid,
+                  'name': running_p.name,
+                  'exitcode': running_p.exitcode,
+                  'alive': running_p.is_alive(),
+                  'killed': False,
+                  'kill-signal': None
+        }
+        if running_p.exitcode != None and running_p.exitcode < 0:
+            result['killed'] = True
+            result['kill-signal'] = running_p.exitcode
+        return result
+
+    result_map = {} # {process-name: process-results, ...}
+
+    #print('pool', list(map(status, pool)))
+    
+    # poll the processes until all are complete
+    # remove process from pool when it is complete
+    while len(pool) > 0:
+        for idx, running_p in enumerate(pool):
+            result = status(running_p)
+            if not result['alive']:
+                result_map[result['name']] = result
+                del pool[idx]
+        time.sleep(0.1)
+        
+    # all processes are complete
+    # empty the queue and marry the results to their process results using their 'name'
+
+    return_list = []
+    while not q.empty():
+        job_result = q.get()
+        # print('got job', job_result)
+        job_name = job_result['name']
+        result_map[job_name]['result'] = job_result['result']
+        return_list.append(job_result['result'])
+
+    #return list(result_map.values())
+    return return_list

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable
+#from collections.abc import Iterable
 import contextlib
 from multiprocessing import Process, Queue
 import os, time
@@ -180,14 +180,14 @@ def execute(env, func, param_key=None, param_values=None):
     # the custom 'JobQueue' adds complexity but can be avoided (I hope):
     # https://github.com/mathiasertl/fabric/blob/master/fabric/job_queue.py
     
-    if (param_key and not param_values) or \
-       (not param_key and param_values):
-        raise ValueException("either a `param_key` AND `param_values` are provided OR neither are provided")
+    if (param_key and param_values == None) or \
+       (param_key == None and param_values):
+        raise ValueError("either a `param_key` AND `param_values` are provided OR neither are provided")
 
-    if param_values and not isinstance(param_values, Iterable):
+    if param_values != None and type(param_values) not in [list, tuple, set]:
         raise ValueError("given value for `param_values` must be an iterable type, not %r" % type(param_values))
 
-    if param_key and not isinstance(param_key, str):
+    if param_key != None and not isinstance(param_key, str):
         raise ValueError("given value for `param_key` must be a valid function parameter key")
     
     if hasattr(func, 'parallel') and func.parallel:

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -16,8 +16,7 @@ ENV = {}
 
 @contextlib.contextmanager
 def settings(state=None, **kwargs):
-    global_state = state == None
-    if global_state:
+    if state == None:
         state = ENV
     if not isinstance(state, dict):
         raise TypeError("state map must be a dictionary-like object, not %r" % type(state))
@@ -26,17 +25,8 @@ def settings(state=None, **kwargs):
     try:
         yield state
     finally:
-        if global_state:
-            #ENV = original_values # doesn't work
-            ENV.clear()
-            ENV.update(original_values)
-            return
-        kwargs.update(original_values)
-        for key, val in kwargs.items():
-            if key not in original_values:
-                del state[key]
-                continue
-            state[key] = original_values[key]
+        state.clear()
+        state.update(original_values)
 
 def serial(func, pool_size=None):
     """Forces the given function to run `pool_size` times.

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -1,8 +1,15 @@
 from collections.abc import Iterable
-import uuid
 import contextlib
 from multiprocessing import Process, Queue
 import os, time
+
+def first(x):
+    try:
+        return x[0]
+    except (KeyError, ValueError, TypeError):
+        return None
+
+#
 
 ENV = {}
 
@@ -58,9 +65,6 @@ def _parallel_execution_worker_wrapper(env, worker_func, name, queue):
         queue.put({'name': name, 'result': result})
     except BaseException as unhandled_exception:
         queue.put({'name': name, 'result': unhandled_exception})
-
-def unique_id():
-    return str(uuid.uuid4())
 
 def _parallel_execution(env, func, param_key, param_values):
 
@@ -129,7 +133,8 @@ def _parallel_execution(env, func, param_key, param_values):
         job_name = job_result['name']
         result_map[job_name]['result'] = job_result['result']
 
-    return list(result_map.values())
+    # sort the results, drop the process name
+    return [b for a, b in sorted(result_map.items(), key=first)]
 
 def _serial_execution(env, func, param_key, param_values):
     result_list = []

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -19,17 +19,17 @@ def settings(state=None, **kwargs):
         state = ENV
     if not isinstance(state, dict):
         raise TypeError("state map must be a dictionary-like object, not %r" % type(state))
-    original = {}
+    original_values = {}
     for key, val in kwargs.items():
         if key in state:
-            original[key] = state[key]
+            original_values[key] = state[key]
         state[key] = val
     try:
         yield state
     finally:
         for key, val in kwargs.items():
-            if key in original:
-                state[key] = original[key]
+            if key in original_values:
+                state[key] = original_values[key]
             else:
                 del state[key]
 


### PR DESCRIPTION
- [x] `execute` runs tasks serially
- [x] `execute` runs tasks in parallel
- [x] worker functions executing in parallel have access to a copy of their parent process's state
- [x] re-think function names. I want access to all of the execution details, especially `exitcode`
- [x] worker function wrappers **always** return successfully, even if their wrapped function doesn't
- [x] do we need to preserve order of results? yes! if we can
- [x] test kill signal somehow
- [x] test bad parameters
- [x] test presence of parent environment
- [x] add tests for `_parallel_execute` function for raw results
- [x] review

---

todo, but not for this PR:

* capture stdout + stderr
* Fabric uses the hosts in the environment to determine process `name`s and `pool_size`. This will need to be accommodated.