### PR TITLE
Feature: remote

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,0 +1,27 @@
+import threadbare
+from threadbare.api import remote
+
+def main():
+    # it's embarassing how nice it is to play with global state...
+    with threadbare.settings(user='elife', host='34.201.187.7', quiet=False, discard_output=False) as env:
+        #result = remote(r'echo -e "\e[31mRed Text\e[0m"', use_shell=False)
+        #result = remote('echo "standard out"; echo "sleeping"; sleep 2; >&2 echo "standard error"; exit 2', combine_stderr=False)
+        #result = remote_sudo('salt-call state.highstate')
+        result = remote('foo=bar; echo "bar? $foo!"', use_shell=False)
+        # read from stdin
+        #result = remote('echo "> "; cat -')
+
+        if env.get('quiet', False) and not env.get('discard_output', False):
+            print('---')
+            for line in result['stdout']:
+                print('out:',line)
+
+            for line in result['stderr']:
+                print('err:',line)
+
+        print('---')
+        
+        print('results:',result)
+    
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pytest
-ssh2-python
+parallel-ssh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+ssh2-python

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,7 +20,7 @@ def test_remote_args_to_execute():
         'user': USER,
         'private_key_file': PEM,
         
-        'use_pty': True,
+        'use_pty': False,
         'command': '/bin/bash -l -c "echo hello"'
     }
 
@@ -40,7 +40,7 @@ def test_remote_sudo_args_to_execute():
         'user': USER,
         'private_key_file': PEM,
 
-        'use_pty': True,
+        'use_pty': False,
         'command': 'sudo --non-interactive /bin/bash -l -c "echo hello"'
     }
     mockobj.assert_called_with(**expected_kwargs)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,69 @@
+import unittest.mock
+from unittest.mock import patch
+from threadbare import api, merge
+
+# simple remote calls
+
+HOST = 'testhost'
+USER = 'testuser'
+PORT = 666
+PEM = "/home/testuser/.ssh/id_rsa"
+
+def test_remote_args_to_execute():
+    "`api.remote` calls `api._execute` with the correct arguments"
+    with patch('threadbare.api._execute') as mockobj:
+        api.remote('echo hello', host=HOST, port=PORT, user=USER, private_key_file=PEM)
+
+    expected_kwargs = {
+        'host': HOST,
+        'port': PORT,
+        'user': USER,
+        'private_key_file': PEM,
+        
+        'use_pty': True,
+        'command': '/bin/bash -l -c "echo hello"'
+    }
+
+    # _execute(command='/bin/bash -l -c "echo hello"', host='testhost', private_key_file='/home/luke/.ssh/id_rsa', use_pty=True, user='testuser')
+    
+    
+    mockobj.assert_called_with(**expected_kwargs)
+
+def test_remote_sudo_args_to_execute():
+    "`api.remote_sudo` calls `api._execute` with the correct arguments"
+    with patch('threadbare.api._execute') as mockobj:
+        api.remote_sudo('echo hello', host=HOST, port=PORT, user=USER, private_key_file=PEM)
+
+    expected_kwargs = {
+        'host': HOST,
+        'port': PORT,
+        'user': USER,
+        'private_key_file': PEM,
+
+        'use_pty': True,
+        'command': 'sudo --non-interactive /bin/bash -l -c "echo hello"'
+    }
+    mockobj.assert_called_with(**expected_kwargs)
+
+# remote calls with non-default args
+
+def test_remote_non_default_args():
+    "`api.remote_sudo` calls `api._execute` with the correct arguments"
+    base = {
+        'host': HOST,
+        'port': PORT,
+        'user': USER,
+        'private_key_file': PEM,
+    }
+    cases = [
+        # non-shell regular command
+        [{'use_shell': False}, {'use_pty': False, 'command': 'echo hello'}],
+
+        # non-shell sudo command
+        [{'use_shell': False, 'use_sudo': True}, {'use_pty': False, 'command': 'sudo --non-interactive echo hello'}]
+    ]
+    for given_kwargs, expected_kwargs in cases:
+        with patch('threadbare.api._execute') as mockobj:
+            api.remote('echo hello', **merge(base, given_kwargs))
+        mockobj.assert_called_with(**merge(base, expected_kwargs))
+    

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,10 +23,6 @@ def test_remote_args_to_execute():
         'use_pty': True,
         'command': '/bin/bash -l -c "echo hello"'
     }
-
-    # _execute(command='/bin/bash -l -c "echo hello"', host='testhost', private_key_file='/home/luke/.ssh/id_rsa', use_pty=True, user='testuser')
-    
-    
     mockobj.assert_called_with(**expected_kwargs)
 
 def test_remote_sudo_args_to_execute():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,7 +20,7 @@ def test_remote_args_to_execute():
         'user': USER,
         'private_key_file': PEM,
         
-        'use_pty': False,
+        'use_pty': True,
         'command': '/bin/bash -l -c "echo hello"'
     }
 
@@ -40,7 +40,7 @@ def test_remote_sudo_args_to_execute():
         'user': USER,
         'private_key_file': PEM,
 
-        'use_pty': False,
+        'use_pty': True,
         'command': 'sudo --non-interactive /bin/bash -l -c "echo hello"'
     }
     mockobj.assert_called_with(**expected_kwargs)
@@ -57,10 +57,13 @@ def test_remote_non_default_args():
     }
     cases = [
         # non-shell regular command
-        [{'use_shell': False}, {'use_pty': False, 'command': 'echo hello'}],
+        [{'use_shell': False}, {'use_pty': True, 'command': 'echo hello'}],
+
+        # non-shell, non-tty command
+        [{'use_shell': False, 'combine_stderr': False}, {'use_pty': False, 'command': 'echo hello'}],
 
         # non-shell sudo command
-        [{'use_shell': False, 'use_sudo': True}, {'use_pty': False, 'command': 'sudo --non-interactive echo hello'}]
+        [{'use_shell': False, 'use_sudo': True}, {'use_pty': True, 'command': 'sudo --non-interactive echo hello'}]
     ]
     for given_kwargs, expected_kwargs in cases:
         with patch('threadbare.api._execute') as mockobj:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,9 @@
-import unittest.mock
+import pytest
+import unittest.mock as mock
 from unittest.mock import patch
-from threadbare import api, merge
+from threadbare import api
+from threadbare.common import merge
+from pssh import exceptions as pssh_exceptions
 
 # simple remote calls
 
@@ -44,13 +47,16 @@ def test_remote_sudo_args_to_execute():
 # remote calls with non-default args
 
 def test_remote_non_default_args():
-    "`api.remote_sudo` calls `api._execute` with the correct arguments"
+    "`api.remote` calls `api._execute` with the correct arguments"
     base = {
         'host': HOST,
         'port': PORT,
         'user': USER,
         'private_key_file': PEM,
+        'command': 'echo hello',
     }
+    
+    # given args, expected args
     cases = [
         # non-shell regular command
         [{'use_shell': False}, {'use_pty': True, 'command': 'echo hello'}],
@@ -59,10 +65,64 @@ def test_remote_non_default_args():
         [{'use_shell': False, 'combine_stderr': False}, {'use_pty': False, 'command': 'echo hello'}],
 
         # non-shell sudo command
-        [{'use_shell': False, 'use_sudo': True}, {'use_pty': True, 'command': 'sudo --non-interactive echo hello'}]
+        [{'use_shell': False, 'use_sudo': True}, {'use_pty': True, 'command': 'sudo --non-interactive echo hello'}],
+
+        # shell, regular command
+        [{'use_shell': True},  {'use_pty': True, 'command': '/bin/bash -l -c "echo hello"'}],
+
+        # shell, sudo command
+        [{'use_shell': True, 'use_sudo': True},  {'use_pty': True, 'command': 'sudo --non-interactive /bin/bash -l -c "echo hello"'}],
+
+        # shell escaping
+        [{'command': 'foo=bar; echo "bar? $foo!"'},  {'use_pty': True, 'command': '/bin/bash -l -c "foo=bar; echo \\"bar? \\$foo!\\""'}],
+
+        # shell escaping, non-shell
+        [{'command': 'foo=bar; echo "bar? $foo!"', 'use_shell': False},  {'use_pty': True, 'command': 'foo=bar; echo "bar? $foo!"'}],
+        
+        # edge cases
+
+        # shell, non-tty command
+        # this may be a parallel-ssh bug. in order to combine output streams, `pty` must be off
+        [{'use_pty': False},  {'use_pty': True, # !!
+                               'command': '/bin/bash -l -c "echo hello"'}],
+
+        # if you really need a `pty`, you'll have to handle separate stdout/stderr streams
+        [{'use_pty': False, 'combine_stderr': False}, {'use_pty': False, 'command': '/bin/bash -l -c "echo hello"'}],
+        
     ]
     for given_kwargs, expected_kwargs in cases:
         with patch('threadbare.api._execute') as mockobj:
-            api.remote('echo hello', **merge(base, given_kwargs))
+            api.remote(**merge(base, given_kwargs))
         mockobj.assert_called_with(**merge(base, expected_kwargs))
-    
+
+def test_remote_command_exception():
+    kwargs = {
+        'host': HOST,
+        'port': PORT,
+        'user': USER,
+        'private_key_file': PEM,
+        'command': 'echo hello',
+    }
+    m = mock.MagicMock()
+    m.run_command = mock.Mock(side_effect=ValueError('earthshatteringkaboom'))
+    with patch('threadbare.api.SSHClient', return_value=m):
+        with pytest.raises(api.NetworkError):
+            api.remote(**kwargs)
+
+def test_remote_command_timeout_exception():
+    kwargs = {
+        'host': HOST,
+        'port': PORT,
+        'user': USER,
+        'private_key_file': PEM,
+        'command': 'echo hello',
+    }
+    m = mock.MagicMock()
+    m.run_command = mock.Mock(side_effect=pssh_exceptions.Timeout('foobar'))
+    with patch('threadbare.api.SSHClient', return_value=m):
+        with pytest.raises(api.NetworkError) as err:
+            api.remote(**kwargs)
+        err = err.value
+        assert type(err.wrapped) == pssh_exceptions.Timeout
+        assert str(err) == 'Timed out trying to connect. foobar'
+

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,43 @@
+from threadbare import common
+
+def test_first():
+    cases = [
+        [None, None],
+        ["", None],
+        [[], None],
+        [(), None],
+        [{}, None],
+
+        ["abc", "a"],
+        [[1, 2, 3], 1],
+        [(3, 2, 1), 3],
+        [{1: 2}, (1, 2)], # non-deterministic in most versions of python, don't do this
+    ]
+    for given, expected in cases:
+        actual = common.first(given)
+        assert expected == actual, "failed on case: %r => %r" % (expected, actual)
+
+def test_merge():
+    cases = [
+        [[{}], {}],
+        [[{}, {}], {}],
+        [[{}, {}, {}], {}],
+
+        [[{}, {'a': 'b'}], {'a': 'b'}],
+        [[{'a': 'b'}, {'a': 'c'}], {'a': 'c'}],
+        [[{'a': 'b'}, {'c': 'd'}], {'a': 'b', 'c': 'd'}],
+    ]
+    for arg_list, expected in cases:
+        actual = common.merge(*arg_list)
+        assert expected == actual, "failed on case: %r => %r" % (expected, actual)
+    
+def test_subdict():
+    cases = [
+        [{}, [], {}],
+        [{}, ['a'], {}],
+        [{'a': 'b'}, ['a'], {'a': 'b'}],
+        [{'a': 'b', 'c': 'd', 'e': 'f'}, ['a', 'e'], {'a': 'b', 'e': 'f'}],
+    ]
+    for d, key_list, expected in cases:
+        actual = common.subdict(d, key_list)
+        assert expected == actual

--- a/tests/test_threadbare.py
+++ b/tests/test_threadbare.py
@@ -241,17 +241,15 @@ def test_execute_many_parallel_raw_results():
     param_key = 'mykey'
     param_values = [1, 2, 3]
     expected = [
-        {'pid': 28000, 'name': 'process--1', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parent': 'environment', 'mykey': 1}},
-        {'pid': 28000, 'name': 'process--2', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parent': 'environment', 'mykey': 2}},
-        {'pid': 28000, 'name': 'process--3', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parent': 'environment', 'mykey': 3}}]
-    results = threadbare._parallel_execution(env, parallel_fn, param_key, param_values)
+        {'name': 'process--1', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parent': 'environment', 'mykey': 1}},
+        {'name': 'process--2', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parent': 'environment', 'mykey': 2}},
+        {'name': 'process--3', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parent': 'environment', 'mykey': 3}}]
+    result_list = threadbare._parallel_execution(env, parallel_fn, param_key, param_values)
 
-    def update(d, k, v):
-        d[k] = v
-        return d
+    # process pid is available but is not compared during testing. it's non-deterministic
+    [result.pop('pid') for result in result_list]
 
-    results = [update(result, 'pid', 28000) for result in expected]
-    assert expected == results
+    assert expected == result_list
 
 def test_parallel_terminate():
     "when a process is terminated, ensure internal state is what we expect it to be"

--- a/tests/test_threadbare.py
+++ b/tests/test_threadbare.py
@@ -45,7 +45,7 @@ def test_deleted_state():
 def test_deleted_state_2():
     "state is restored when a value is removed"
     env = {'foo': 'bar'}
-    with settings(env) as newenv:
+    with settings(env):
         env.pop('foo')
         assert env == {}
     assert env == {'foo': 'bar'}

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -99,8 +99,6 @@ def _parallel_execution(env, func, param_key, param_values, return_process_pool=
 
     result_map = {} # {process-name: process-results, ...}
 
-    #print('pool', list(map(status, pool)))
-    
     # poll the processes until all are complete
     # remove process from pool when it is complete
     while len(pool) > 0:

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -6,13 +6,6 @@ from threadbare.common import subdict, merge, first
 
 ENV = {}
 
-# TODO: tests. this is just like subdict
-def get_settings(state=None, key_list=None):
-    key_list = key_list or []
-    if state == None:
-        state = ENV
-    return subdict(state, key_list)
-
 @contextlib.contextmanager
 def settings(state=None, **kwargs):
     if state == None:

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -9,9 +9,26 @@ def first(x):
     except (KeyError, ValueError, TypeError):
         return None
 
+# TODO: tests
+def merge(*dict_list):
+    from functools import reduce
+    def reduce_fn(a, b=None):
+        c = {}
+        c.update(a)
+        c.update(b or {})
+        return c
+    return reduce(reduce_fn, dict_list)
+
 #
 
 ENV = {}
+
+# TODO: tests. this is just like subdict
+def get_settings(state=None, key_list=None):
+    key_list = key_list or []
+    if state == None:
+        state = ENV
+    return {key: state[key] for key in key_list if key in state}
 
 @contextlib.contextmanager
 def settings(state=None, **kwargs):

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -2,24 +2,7 @@ import copy
 import contextlib
 from multiprocessing import Process, Queue
 import os, time
-
-def first(x):
-    try:
-        return x[0]
-    except (KeyError, ValueError, TypeError):
-        return None
-
-# TODO: tests
-def merge(*dict_list):
-    from functools import reduce
-    def reduce_fn(a, b=None):
-        c = {}
-        c.update(a)
-        c.update(b or {})
-        return c
-    return reduce(reduce_fn, dict_list)
-
-#
+from threadbare.common import subdict, merge, first
 
 ENV = {}
 
@@ -28,7 +11,7 @@ def get_settings(state=None, key_list=None):
     key_list = key_list or []
     if state == None:
         state = ENV
-    return {key: state[key] for key in key_list if key in state}
+    return subdict(state, key_list)
 
 @contextlib.contextmanager
 def settings(state=None, **kwargs):

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -1,8 +1,8 @@
 import copy
 import contextlib
 from multiprocessing import Process, Queue
-import os, time
-from threadbare.common import subdict, merge, first
+import time
+from threadbare.common import first
 
 ENV = {}
 

--- a/threadbare/api.py
+++ b/threadbare/api.py
@@ -1,0 +1,137 @@
+import os
+import socket
+from ssh2.session import Session
+
+# direct copy from fabric:
+# https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L33-L46
+def _shell_escape(string):
+    """
+    Escape double quotes, backticks and dollar signs in given ``string``.
+    For example::
+        >>> _shell_escape('abc$')
+        'abc\\\\$'
+        >>> _shell_escape('"')
+        '\\\\"'
+    """
+    for char in ('"', '$', '`'):
+        string = string.replace(char, '\%s' % char)
+    return string
+
+def shell_wrap_command(command):
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/state.py#L253-L256
+    # '-l' is 'login' shell
+    # '-c' is 'run command'
+    space = " "
+    shell_prefix = "/bin/bash -l -c"
+
+    escaped_command = _shell_escape(command)
+    escaped_wrapped_command = '"%s"' % escaped_command
+
+    final_command = shell_prefix + space + escaped_wrapped_command
+
+    return final_command
+
+def sudo_wrap_command(command):
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L605-L623
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/state.py#L374-L376
+    # note: differs from Fabric. they support interactive input of password, users and groups
+    # we use it exclusively to run commands as root
+    sudo_prefix = "sudo --non-interactive"
+    space = " "
+    return sudo_prefix + space + command
+
+#
+
+# https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L726-L856
+def _execute(command, use_pty=False, **kwargs):
+    username = 'elife'
+    host, port = '34.201.187.7', 22
+    
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect((host, port))
+    
+    session = Session()
+    session.handshake(sock)
+    
+    #print(session.userauth_list(username)) # list of authentication methods available
+
+    private_key_file = os.path.expanduser("~/.ssh/id_rsa")
+    session.userauth_publickey_fromfile(username, private_key_file)
+    
+    # executing commands
+    channel = session.open_session()
+
+    if use_pty:
+        # https://ssh2-python.readthedocs.io/en/latest/channel.html#ssh2.channel.Channel.pty
+        channel.pty()
+    
+    channel.execute(command)
+
+    # reading output
+    size, data = channel.read()
+    buff = b''
+    while(size > 0):
+        # this will print the data out in chunks of $size until all is read
+        #print(data.decode('utf-8'))
+
+        # this will buffer the output in memory
+        buff += data
+        size, data = channel.read()
+
+    return {
+        'return_code': channel.get_exit_status(),
+        'command': command,
+        'bytes': buff,
+        'lines': lambda: buff.decode('utf-8').splitlines()
+    }
+
+# https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L898-L901
+# https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L975
+def remote(command, use_sudo=False, use_shell=True, **kwargs):
+    #shell=True # done
+    #pty=True   # done
+    #combine_stderr=None
+    #quiet=False,
+    #warn_only=False
+    #stdout=None # todo
+    #stderr=None # todo
+    #timeout=None # todo
+    #shell_escape=None
+    #capture_buffer_size=None
+    
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L920-L925
+    
+    if use_shell:
+        command = shell_wrap_command(command)
+    if use_sudo:
+        command = sudo_wrap_command(command)
+
+    # the two are not synonymous, but we'll pretend they are
+    # we get ansi control characters (colours!) when a pseudo terminal is requested
+    use_pty = use_shell 
+        
+    return _execute(command, use_pty)
+
+# https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L1100
+def remote_sudo(command, **kwargs):
+    # user=None
+    # group=None
+    return remote(command, use_sudo=True, **kwargs)
+
+#
+#
+#
+
+def main():
+    #result = remote_sudo('salt-call pillar.items')
+    result = remote('echo hi')
+    result = remote('echo -e "\e[31mRed Text\e[0m"', use_shell=False)
+    print('---')
+    for line in result['lines']():
+        print(line)
+    print('---')
+    #del result['bytes']
+    print(result)
+    
+if __name__ == '__main__':
+    main()

--- a/threadbare/api.py
+++ b/threadbare/api.py
@@ -2,8 +2,7 @@ from pssh.clients.native import SSHClient
 import os, sys
 import socket
 import threadbare
-from threadbare import merge
-from threadbare.common import update, identity
+from threadbare.common import merge, update, identity, subdict
 from functools import partial
 
 # utils
@@ -91,11 +90,8 @@ def streaming_print(output_pipe, quiet, discard_output, line):
         return line
 
 def _process_output(output_pipe, result_list, quiet, discard_output):
-    cmd_kwargs = {
-        'quiet': quiet,
-        'discard_output': discard_output
-    }
-    global_kwargs = threadbare.get_settings(key_list=['quiet', 'discard_output'])
+    cmd_kwargs = subdict(locals(), ['quiet', 'discard_output'])
+    global_kwargs = subdict(threadbare.ENV, ['quiet', 'discard_output'])
     kwargs = merge(cmd_kwargs, global_kwargs)
 
     # always process the results as soon as we have them
@@ -134,7 +130,7 @@ def remote(command, use_shell=True, use_sudo=False, combine_stderr=True, quiet=F
     use_pty = combine_stderr
 
     # values stored in global state, if any (global state is *empty* by default)
-    global_kwargs = threadbare.get_settings(key_list=['user', 'host', 'port', 'private_key_file'])
+    global_kwargs = subdict(threadbare.ENV, ['user', 'host', 'port', 'private_key_file'])
 
     # values that would otherwise be function parameter defaults or calculated somewhere
     # should these live here?
@@ -144,7 +140,7 @@ def remote(command, use_shell=True, use_sudo=False, combine_stderr=True, quiet=F
     }
 
     # values the user has passed in - *explicit* overrides
-    user_kwargs = threadbare.get_settings(kwargs, key_list=['user', 'host', 'port', 'private_key_file'])
+    user_kwargs = subdict(kwargs, ['user', 'host', 'port', 'private_key_file'])
 
     # values `remote` specifically passes to `_execute`, overriding all others
     cmd_kwargs = {

--- a/threadbare/api.py
+++ b/threadbare/api.py
@@ -1,9 +1,14 @@
 import os
 import socket
 from ssh2.session import Session
+import threadbare
+from threadbare import merge
 
-# direct copy from fabric:
+# utils
+
+# direct copy from Fabric:
 # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L33-L46
+# TODO: adjust licence accordingly
 def _shell_escape(string):
     """
     Escape double quotes, backticks and dollar signs in given ``string``.
@@ -14,24 +19,30 @@ def _shell_escape(string):
         '\\\\"'
     """
     for char in ('"', '$', '`'):
-        string = string.replace(char, '\%s' % char)
+        string = string.replace(char, r'\%s' % char)
     return string
 
+# https://github.com/mathiasertl/fabric/blob/master/fabric/state.py#L253-L256
 def shell_wrap_command(command):
-    # https://github.com/mathiasertl/fabric/blob/master/fabric/state.py#L253-L256
+    """wraps the given command in a shell invocation.
+    default shell is /bin/bash (like Fabric)
+    no support for configurable shell at present"""
+
     # '-l' is 'login' shell
     # '-c' is 'run command'
-    space = " "
     shell_prefix = "/bin/bash -l -c"
 
     escaped_command = _shell_escape(command)
     escaped_wrapped_command = '"%s"' % escaped_command
 
+    space = " "
     final_command = shell_prefix + space + escaped_wrapped_command
 
     return final_command
 
 def sudo_wrap_command(command):
+    """adds a 'sudo' prefix to command to run as root. 
+    no support for sudo'ing to configurable users/groups"""
     # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L605-L623
     # https://github.com/mathiasertl/fabric/blob/master/fabric/state.py#L374-L376
     # note: differs from Fabric. they support interactive input of password, users and groups
@@ -40,41 +51,30 @@ def sudo_wrap_command(command):
     space = " "
     return sudo_prefix + space + command
 
-#
+# api
 
 # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L726-L856
-def _execute(command, use_pty=False, **kwargs):
-    username = 'elife'
-    host, port = '34.201.187.7', 22
-    
+def _execute(command, user, private_key_file, host, port, use_pty):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.connect((host, port))
     
     session = Session()
     session.handshake(sock)
     
-    #print(session.userauth_list(username)) # list of authentication methods available
-
-    private_key_file = os.path.expanduser("~/.ssh/id_rsa")
-    session.userauth_publickey_fromfile(username, private_key_file)
-    
-    # executing commands
+    session.userauth_publickey_fromfile(user, private_key_file)
     channel = session.open_session()
 
-    if use_pty:
-        # https://ssh2-python.readthedocs.io/en/latest/channel.html#ssh2.channel.Channel.pty
-        channel.pty()
-    
+    # https://ssh2-python.readthedocs.io/en/latest/channel.html#ssh2.channel.Channel.pty
+    use_pty and channel.pty()
+
+    # https://ssh2-python.readthedocs.io/en/latest/channel.html#ssh2.channel.Channel.execute
     channel.execute(command)
 
     # reading output
     size, data = channel.read()
     buff = b''
     while(size > 0):
-        # this will print the data out in chunks of $size until all is read
-        #print(data.decode('utf-8'))
-
-        # this will buffer the output in memory
+        # buffers output in ram
         buff += data
         size, data = channel.read()
 
@@ -82,12 +82,15 @@ def _execute(command, use_pty=False, **kwargs):
         'return_code': channel.get_exit_status(),
         'command': command,
         'bytes': buff,
-        'lines': lambda: buff.decode('utf-8').splitlines()
+
+        # todo: the buffered output and this need to be re-thought.
+        # probably when I take a look at how stdout/stderr/stdin pipes are handled
+        'lines': lambda: buff.decode('utf-8').splitlines(),
     }
 
 # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L898-L901
 # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L975
-def remote(command, use_sudo=False, use_shell=True, **kwargs):
+def remote(command, use_shell=True, use_sudo=False, **kwargs): #host=None, port=None, private_key_file=None, use_sudo=False, use_shell=True, **kwargs):
     #shell=True # done
     #pty=True   # done
     #combine_stderr=None
@@ -98,40 +101,63 @@ def remote(command, use_sudo=False, use_shell=True, **kwargs):
     #timeout=None # todo
     #shell_escape=None
     #capture_buffer_size=None
-    
+
+    # wrap the command up
     # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L920-L925
-    
     if use_shell:
         command = shell_wrap_command(command)
     if use_sudo:
         command = sudo_wrap_command(command)
 
-    # the two are not synonymous, but we'll pretend they are
-    # we get ansi control characters (colours!) when a pseudo terminal is requested
-    use_pty = use_shell 
-        
-    return _execute(command, use_pty)
+    # values stored in global state, if any (global state is *empty* by default)
+    global_kwargs = threadbare.get_settings(key_list=['user', 'host', 'port', 'private_key_file'])
+
+    # values that would otherwise be function parameter defaults or calculated somewhere
+    # should these live here?
+    base_kwargs = {
+        'private_key_file': os.path.expanduser("~/.ssh/id_rsa"),
+        'port': 22
+    }
+
+    # values the user has passed in - *explicit* overrides
+    user_kwargs = threadbare.get_settings(kwargs, key_list=['user', 'host', 'port', 'private_key_file'])
+
+    # values `remote` specifically passes to `_execute`, overriding all others
+    cmd_kwargs = {
+        'command': command,
+
+        # the two are not synonymous, but we'll pretend they are
+        # we get ansi control characters (colours!) when salt detects a pseudo terminal
+        'use_pty': use_shell,
+    }
+
+    # final dictionary of keyword parameters that `_execute` receives
+    final_kwargs = merge(global_kwargs, base_kwargs, user_kwargs, cmd_kwargs)
+
+    return _execute(**final_kwargs)
 
 # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L1100
 def remote_sudo(command, **kwargs):
-    # user=None
-    # group=None
-    return remote(command, use_sudo=True, **kwargs)
+    # user=None  # ignore
+    # group=None # ignore
+    kwargs['use_sudo'] = True
+    return remote(command, **kwargs)
 
 #
 #
 #
 
 def main():
-    #result = remote_sudo('salt-call pillar.items')
-    result = remote('echo hi')
-    result = remote('echo -e "\e[31mRed Text\e[0m"', use_shell=False)
-    print('---')
-    for line in result['lines']():
-        print(line)
-    print('---')
-    #del result['bytes']
-    print(result)
+    # it's embarassing how nice it is to play with global state...
+    with threadbare.settings(user='elife', host='34.201.187.7'):
+        result = remote_sudo('salt-call pillar.items')
+        #result = remote_sudo(r'echo -e "\e[31mRed Text\e[0m"', use_shell=False)
+        print('---')
+        for line in result['lines']():
+            print(line)
+        print('---')
+        del result['bytes'] # noisy
+        print(result)
     
 if __name__ == '__main__':
     main()

--- a/threadbare/api.py
+++ b/threadbare/api.py
@@ -180,8 +180,10 @@ def main():
     # it's embarassing how nice it is to play with global state...
     with threadbare.settings(user='elife', host='34.201.187.7', quiet=False, discard_output=False) as env:
         #result = remote(r'echo -e "\e[31mRed Text\e[0m"', use_shell=False)
-        result = remote('echo "standard out"; echo "sleeping"; sleep 2; >&2 echo "standard error"; exit 2', combine_stderr=False)
+        #result = remote('echo "standard out"; echo "sleeping"; sleep 2; >&2 echo "standard error"; exit 2', combine_stderr=False)
         #result = remote_sudo('salt-call state.highstate')
+        # read from stdin
+        result = remote('echo "> "; cat -')
 
         if env.get('quiet', False) and not env.get('discard_output', False):
             print('---')

--- a/threadbare/api.py
+++ b/threadbare/api.py
@@ -96,7 +96,7 @@ def remote(command, use_shell=True, use_sudo=False, combine_stderr=True, **kwarg
 
     # if use_pty is True, stdout and stderr are combined and stderr will yield nothing.
     # bug or expected behaviour in parallel-ssh?
-    use_pty = not combine_stderr # combine_stderr is True by default
+    use_pty = combine_stderr
 
     # values stored in global state, if any (global state is *empty* by default)
     global_kwargs = threadbare.get_settings(key_list=['user', 'host', 'port', 'private_key_file'])
@@ -142,7 +142,7 @@ def main():
     with threadbare.settings(user='elife', host='34.201.187.7'):
         #result = remote_sudo('salt-call pillar.items')
         #result = remote_sudo(r'echo -e "\e[31mRed Text\e[0m"', use_shell=False)
-        result = remote('echo "standard out"; >&2 echo "standard error"')
+        result = remote('echo "standard out"; >&2 echo "standard error"', combine_stderr=False)
         print('---')
 
         for line in result['stdout']:
@@ -152,7 +152,7 @@ def main():
             print('stderr:',line)
 
         print('---')
-        print('results:',result)
+        #print('results:',result)
     
 if __name__ == '__main__':
     main()

--- a/threadbare/api.py
+++ b/threadbare/api.py
@@ -1,7 +1,36 @@
 from pssh.clients.native import SSHClient
+from pssh import exceptions as pssh_exceptions
 import os, sys
 import threadbare
 from threadbare.common import merge, subdict
+
+class NetworkError(BaseException):
+    """generic 'died while doing something ssh-related' catch-all exception class.
+    calling str() on this exception will return the results on calling str() on the 
+    wrapped exception."""
+    def __init__(self, wrapped_exception_inst):
+        self.wrapped = wrapped_exception_inst
+
+    def __str__(self):
+        # we have the opportunity here to tweak the error messages to make them
+        # similar with their equivalents in Fabric.
+        # original error messages are still available via `str(exinst.wrapped)`
+        space = " "
+        custom_error_prefixes = {
+            # builder: https://github.com/elifesciences/builder/blob/master/src/buildercore/core.py#L345-L347
+            # pssh: https://github.com/ParallelSSH/parallel-ssh/blob/8b7bb4bcb94d913c3b7da77db592f84486c53b90/pssh/clients/native/parallel.py#L272-L274
+            pssh_exceptions.Timeout: "Timed out trying to connect." + space,
+
+            # builder: https://github.com/elifesciences/builder/blob/master/src/buildercore/core.py#L348-L350
+            # fabric: https://github.com/mathiasertl/fabric/blob/master/fabric/network.py#L601-L605
+            # pssh: https://github.com/ParallelSSH/parallel-ssh/blob/2e9668cf4b58b38316b1d515810d7e6c595c76f3/pssh/exceptions.py
+            pssh_exceptions.SSHException: "Low level socket error connecting to host." + space,
+            pssh_exceptions.SessionError: "Low level socket error connecting to host." + space,
+            pssh_exceptions.ConnectionErrorException: "Low level socket error connecting to host." + space,
+        }
+        new_error = custom_error_prefixes.get(type(self.wrapped)) or ""
+        original_error = str(self.wrapped)
+        return new_error + original_error
 
 # utils
 
@@ -52,9 +81,15 @@ def sudo_wrap_command(command):
 
 # api
 
+# todo: 'api.py' and '__init__.py' are poorly named and this function + a `local` function
+# should probably be wrapped `__init__/execute`
 def _execute(command, user, private_key_file, host, port, use_pty):
+    """creates an SSHClient object and executes given `command` with the given parameters.
+    it does not consult global state and all parameters must be explicitly passed in.
+    keep this function as simple as possible."""
+
     # https://parallel-ssh.readthedocs.io/en/latest/native_single.html#pssh.clients.native.single.SSHClient
-    password = None
+    password = None # we *never* use passwords, not even for bootstrapping. always private keys.
     client = SSHClient(host, user, password, port, pkey=private_key_file)
     
     # https://github.com/ParallelSSH/parallel-ssh/blob/1.9.1/pssh/clients/native/single.py#L408
@@ -62,18 +97,27 @@ def _execute(command, user, private_key_file, host, port, use_pty):
     shell = False # handled ourselves
     timeout = None # todo
     encoding = 'utf-8' # default everywhere
-    channel, host, stdout, stderr, stdin = client.run_command(command, sudo, user, use_pty, shell, encoding, timeout)
 
-    def get_exitcode():
-        client.wait_finished(channel) # timeout here
-        return channel.get_exit_status()
+    try:
+        channel, host, stdout, stderr, stdin = client.run_command(command, sudo, user, use_pty, shell, encoding, timeout)
 
-    return {
-        'return_code': get_exitcode,
-        'command': command,
-        'stdout': stdout,
-        'stderr': stderr,
-    }
+        def get_exitcode():
+            """we can't know the exit code until command has finished running.
+            attempting to realise the exitcode will cause the thread of execution to block until 
+            the channel is finished"""
+            client.wait_finished(channel) # `timeout` here
+            return channel.get_exit_status()
+
+        return {
+            'return_code': get_exitcode,
+            'command': command,
+            'stdout': stdout,
+            'stderr': stderr,
+        }
+    except BaseException as ex:
+        # *most likely* a network error:
+        # https://github.com/ParallelSSH/parallel-ssh/blob/master/pssh/exceptions.py
+        raise NetworkError(ex)
 
 def streaming_print(output_pipe, quiet, discard_output, line):
     """writes the given `line` (string) to the given `output_pipe` (file-like object) if `quiet` is True. 
@@ -150,7 +194,8 @@ def remote(command, use_shell=True, use_sudo=False, combine_stderr=True, quiet=F
     final_kwargs = merge(base_kwargs, user_kwargs, global_kwargs, cmd_kwargs)
 
     # print('args to execute:',final_kwargs)
-    
+
+
     result = _execute(**final_kwargs)
 
     result.update({
@@ -162,6 +207,7 @@ def remote(command, use_shell=True, use_sudo=False, combine_stderr=True, quiet=F
     })
 
     return result
+
 
 # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L1100
 def remote_sudo(command, **kwargs):
@@ -180,8 +226,9 @@ def main():
         #result = remote(r'echo -e "\e[31mRed Text\e[0m"', use_shell=False)
         #result = remote('echo "standard out"; echo "sleeping"; sleep 2; >&2 echo "standard error"; exit 2', combine_stderr=False)
         #result = remote_sudo('salt-call state.highstate')
+        result = remote('foo=bar; echo "bar? $foo!"', use_shell=False)
         # read from stdin
-        result = remote('echo "> "; cat -')
+        #result = remote('echo "> "; cat -')
 
         if env.get('quiet', False) and not env.get('discard_output', False):
             print('---')

--- a/threadbare/api.py
+++ b/threadbare/api.py
@@ -1,9 +1,7 @@
 from pssh.clients.native import SSHClient
 import os, sys
-import socket
 import threadbare
-from threadbare.common import merge, update, identity, subdict
-from functools import partial
+from threadbare.common import merge, subdict
 
 # utils
 

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -1,21 +1,14 @@
 from functools import reduce
 
 def first(x):
+    "returns the first element in an collection of things"
     try:
         return x[0]
-    except (KeyError, ValueError, TypeError):
+    except (KeyError, ValueError):
         return None
 
 def merge(*dict_list):
-    def reduce_fn(a, b=None):
-        c = {}
-        c.update(a)
-        c.update(b or {})
-        return c
-    return reduce(reduce_fn, dict_list)
-
-def merge2(*dict_list):
-    "merges a list of dictionaries from left to right"
+    "non-destructively merges a series of dictionaries from left to right, returning a new dictionary"
     def reduce_fn(a, b=None):
         c = {}
         c.update(a)
@@ -24,12 +17,6 @@ def merge2(*dict_list):
     return reduce(reduce_fn, dict_list)
 
 def subdict(d, key_list):
+    "returns a subset of the given dictionary `d` for keys in `key_list`"
     key_list = key_list or []
     return {key: d[key] for key in key_list if key in d}
-
-def update(d, k, v):
-    d[k] = v
-    return d
-
-def identity(x):
-    return x

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -2,9 +2,13 @@ from functools import reduce
 
 def first(x):
     "returns the first element in an collection of things"
+    if x == None:
+        return x
     try:
+        if isinstance(x, dict):
+            return list(x.items())[0]
         return x[0]
-    except (KeyError, ValueError):
+    except (ValueError, IndexError):
         return None
 
 def merge(*dict_list):

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -14,6 +14,15 @@ def merge(*dict_list):
         return c
     return reduce(reduce_fn, dict_list)
 
+def merge2(*dict_list):
+    "merges a list of dictionaries from left to right"
+    def reduce_fn(a, b=None):
+        c = {}
+        c.update(a)
+        c.update(b or {})
+        return c
+    return reduce(reduce_fn, dict_list)
+
 def subdict(d, key_list):
     key_list = key_list or []
     return {key: d[key] for key in key_list if key in d}

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -13,11 +13,11 @@ def first(x):
 
 def merge(*dict_list):
     "non-destructively merges a series of dictionaries from left to right, returning a new dictionary"
-    def reduce_fn(a, b=None):
-        c = {}
-        c.update(a)
-        c.update(b or {})
-        return c
+    def reduce_fn(d1, d2=None):
+        d3 = {}
+        d3.update(d1)
+        d3.update(d2 or {})
+        return d3
     return reduce(reduce_fn, dict_list)
 
 def subdict(d, key_list):

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -1,0 +1,26 @@
+from functools import reduce
+
+def first(x):
+    try:
+        return x[0]
+    except (KeyError, ValueError, TypeError):
+        return None
+
+def merge(*dict_list):
+    def reduce_fn(a, b=None):
+        c = {}
+        c.update(a)
+        c.update(b or {})
+        return c
+    return reduce(reduce_fn, dict_list)
+
+def subdict(d, key_list):
+    key_list = key_list or []
+    return {key: d[key] for key in key_list if key in d}
+
+def update(d, k, v):
+    d[k] = v
+    return d
+
+def identity(x):
+    return x


### PR DESCRIPTION
todo:
- [x] force all the socket logic out to the periphery. it's difficult to test
- [x] capture stdout and stderr
- [x] allow combination of stdout and stderr (default?)
- [x] investigate what happens when stdin is requested (what does *builder* do??)
- [x] review
- [x] put together a simple demo using `settings`, `parallel` and `remote`