### PR TITLE
Reusable network connections

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,7 +1,22 @@
+from threadbare import operations, state
 from threadbare.state import settings
-from threadbare import operations
+from threadbare.operations import remote
 
-def handle_result(result):
+def handle_result_1(result):
+    env = state.ENV # global mutable state, beware.
+    if env.get('quiet', False) and not env.get('discard_output', False):
+        print('---')
+        for line in result['stdout']:
+            print('out:',line)
+
+        for line in result['stderr']:
+            print('err:',line)
+
+    print('---')
+        
+    print('results:',result)
+
+def handle_result_2(result):
     with settings() as env:
         if env.get('quiet', False) and not env.get('discard_output', False):
             print('---')
@@ -16,7 +31,17 @@ def handle_result(result):
         print('results:',result)
 
 def main():
-    # it's embarassing how nice it is to play with global state...
+    with settings(nest=0):
+        print('hi')
+        with settings(nest=1):
+            print('hello')
+            with settings(nest=2):
+                print('hey')
+
+    assert state.ENV.read_only
+                
+    return
+    
     with settings(user='elife', host_string='34.201.187.7', quiet=False, discard_output=False):
         #result = remote(r'echo -e "\e[31mRed Text\e[0m"', use_shell=False)
         #result = remote('echo "standard out"; echo "sleeping"; sleep 2; >&2 echo "standard error"; exit 2', combine_stderr=False)
@@ -34,14 +59,14 @@ def main():
             "echo are",
             "echo you?",
         ]
-        #for command in command_list:
-        #    handle_result(remote(command))
+        for command in command_list:
+            handle_result_1(remote(command))
+            
         #print(remote_file_exists('/tmp'))
-
         #operations.download('/var/log/daily-logrotate.log', '/tmp/daily-logrotate.log')
-        operations.remote('rm /tmp/payload')
-        operations.upload('/tmp/payload', '/tmp/payload')
-        assert operations.remote_file_exists('/tmp/payload'), "file failed to upload"
+        #operations.remote('rm /tmp/payload')
+        #operations.upload('/tmp/payload', '/tmp/payload')
+        #assert operations.remote_file_exists('/tmp/payload'), "file failed to upload"
 
     print('done')
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,7 +1,7 @@
 import pytest
 import unittest.mock as mock
 from unittest.mock import patch
-from threadbare import operations, state
+from threadbare import operations
 from threadbare.common import merge
 from pssh import exceptions as pssh_exceptions
 
@@ -91,10 +91,9 @@ def test_remote_non_default_args():
         
     ]
     for given_kwargs, expected_kwargs in cases:
-        with state.settings():
-            with patch('threadbare.operations._execute') as mockobj:
-                operations.remote(**merge(base, given_kwargs))
-                mockobj.assert_called_with(**merge(base, expected_kwargs))
+        with patch('threadbare.operations._execute') as mockobj:
+            operations.remote(**merge(base, given_kwargs))
+            mockobj.assert_called_with(**merge(base, expected_kwargs))
 
 def test_remote_command_exception():
     kwargs = {
@@ -106,10 +105,9 @@ def test_remote_command_exception():
     }
     m = mock.MagicMock()
     m.run_command = mock.Mock(side_effect=ValueError('earthshatteringkaboom'))
-    with state.settings():
-        with patch('threadbare.operations.SSHClient', return_value=m):
-            with pytest.raises(operations.NetworkError):
-                operations.remote(**kwargs)
+    with patch('threadbare.operations.SSHClient', return_value=m):
+        with pytest.raises(operations.NetworkError):
+            operations.remote(**kwargs)
 
 def test_remote_command_timeout_exception():
     kwargs = {
@@ -121,13 +119,12 @@ def test_remote_command_timeout_exception():
     }
     m = mock.MagicMock()
     m.run_command = mock.Mock(side_effect=pssh_exceptions.Timeout('foobar'))
-    with state.settings():
-        with patch('threadbare.operations.SSHClient', return_value=m):
-            with pytest.raises(operations.NetworkError) as err:
-                operations.remote(**kwargs)
-            err = err.value
-            assert type(err.wrapped) == pssh_exceptions.Timeout
-            assert str(err) == 'Timed out trying to connect. foobar'
+    with patch('threadbare.operations.SSHClient', return_value=m):
+        with pytest.raises(operations.NetworkError) as err:
+            operations.remote(**kwargs)
+        err = err.value
+        assert type(err.wrapped) == pssh_exceptions.Timeout
+        assert str(err) == 'Timed out trying to connect. foobar'
 
 #
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,7 +1,7 @@
 import pytest
 import unittest.mock as mock
 from unittest.mock import patch
-from threadbare import operations
+from threadbare import operations, state
 from threadbare.common import merge
 from pssh import exceptions as pssh_exceptions
 
@@ -91,9 +91,10 @@ def test_remote_non_default_args():
         
     ]
     for given_kwargs, expected_kwargs in cases:
-        with patch('threadbare.operations._execute') as mockobj:
-            operations.remote(**merge(base, given_kwargs))
-        mockobj.assert_called_with(**merge(base, expected_kwargs))
+        with state.settings():
+            with patch('threadbare.operations._execute') as mockobj:
+                operations.remote(**merge(base, given_kwargs))
+                mockobj.assert_called_with(**merge(base, expected_kwargs))
 
 def test_remote_command_exception():
     kwargs = {
@@ -105,9 +106,10 @@ def test_remote_command_exception():
     }
     m = mock.MagicMock()
     m.run_command = mock.Mock(side_effect=ValueError('earthshatteringkaboom'))
-    with patch('threadbare.operations.SSHClient', return_value=m):
-        with pytest.raises(operations.NetworkError):
-            operations.remote(**kwargs)
+    with state.settings():
+        with patch('threadbare.operations.SSHClient', return_value=m):
+            with pytest.raises(operations.NetworkError):
+                operations.remote(**kwargs)
 
 def test_remote_command_timeout_exception():
     kwargs = {
@@ -119,12 +121,13 @@ def test_remote_command_timeout_exception():
     }
     m = mock.MagicMock()
     m.run_command = mock.Mock(side_effect=pssh_exceptions.Timeout('foobar'))
-    with patch('threadbare.operations.SSHClient', return_value=m):
-        with pytest.raises(operations.NetworkError) as err:
-            operations.remote(**kwargs)
-        err = err.value
-        assert type(err.wrapped) == pssh_exceptions.Timeout
-        assert str(err) == 'Timed out trying to connect. foobar'
+    with state.settings():
+        with patch('threadbare.operations.SSHClient', return_value=m):
+            with pytest.raises(operations.NetworkError) as err:
+                operations.remote(**kwargs)
+            err = err.value
+            assert type(err.wrapped) == pssh_exceptions.Timeout
+            assert str(err) == 'Timed out trying to connect. foobar'
 
 #
 

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -24,3 +24,10 @@ def subdict(d, key_list):
     "returns a subset of the given dictionary `d` for keys in `key_list`"
     key_list = key_list or []
     return {key: d[key] for key in key_list if key in d}
+
+def rename(d, pair_list):
+    "mutator. given a dictionary `d` and a list of (old-name, new-name) pairs, renames old-name to new-name, if it exists"
+    for old, new in pair_list:
+        if old in d:
+            d[new] = d[old]
+            del d[old]

--- a/threadbare/execute.py
+++ b/threadbare/execute.py
@@ -30,8 +30,8 @@ def _parallel_execution_worker_wrapper(env, worker_func, name, queue):
         # implicit `settings() as env` invocation rather than `settings(env)` as we have
         # no reference to `env` unless the worker function accepts it as a parameter.
         # and we can't rely on that.
-        if env:
-            state.ENV.update(env)
+        state.read_write(state.ENV)
+        state.ENV.update(env or {})
         result = worker_func()
         queue.put({'name': name, 'result': result})
     except BaseException as unhandled_exception:

--- a/threadbare/operations.py
+++ b/threadbare/operations.py
@@ -1,10 +1,17 @@
 import subprocess
 import getpass
-from pssh.clients.native import SSHClient
+from pssh.clients.native import SSHClient as PSSHClient
 from pssh import exceptions as pssh_exceptions
 import os, sys
 from threadbare import state
 from threadbare.common import merge, subdict
+
+class SSHClient(PSSHClient):
+    # what we're saying is *don't* deepcopy the pssh SSHClient object,
+    # return a reference to the object (self)
+    # - https://docs.python.org/3/library/copy.html
+    def __deepcopy__(self, memo):
+        return self
 
 class NetworkError(BaseException):
     """generic 'died while doing something ssh-related' catch-all exception class.

--- a/threadbare/state.py
+++ b/threadbare/state.py
@@ -1,6 +1,8 @@
 import copy
 import contextlib
 
+CLEANUP_KEY = "_cleanup"
+
 class LockableDict(dict):
     # unlocked by default
     # when multiprocessing starts a new process the ENV it has access to is not the same one
@@ -8,7 +10,8 @@ class LockableDict(dict):
     read_only = False
     
     def __setitem__(self, key, val):
-        if self.read_only:
+        #exceptions = [CLEANUP_KEY]
+        if self.read_only: # and key not in exceptions:
             raise ValueError("dictionary is locked attempting to write %r with %r" % (key, val))
         dict.__setitem__(self, key, val)
 
@@ -23,6 +26,29 @@ def read_write(d):
 ENV = LockableDict()
 read_only(ENV)
 
+def cleanup(old_env):
+    if True:
+        return
+    if CLEANUP_KEY in old_env:
+        for cleanup_fn in old_env[CLEANUP_KEY]:
+            cleanup_fn()
+        del old_env[CLEANUP_KEY]
+
+def add_cleanup(fn):
+    if True:
+        return
+    cleanup_fn_list = ENV.get(CLEANUP_KEY, [])
+    cleanup_fn_list.append(fn)
+    ENV[CLEANUP_KEY] = cleanup_fn_list
+
+def deepish_copy(x):
+    if isinstance(x, dict):
+        return {k: deepish_copy(v) for k, v in x.items()}
+    if isinstance(x, list):
+        return [deepish_copy(v) for v in x]
+
+    return copy.copy(x)
+
 @contextlib.contextmanager
 def settings(state=None, **kwargs):
     if state == None:
@@ -30,12 +56,16 @@ def settings(state=None, **kwargs):
     if not isinstance(state, dict):
         raise TypeError("state map must be a dictionary-like object, not %r" % type(state))
 
-    read_write(state)    
-    original_values = copy.deepcopy(state)
+    read_write(state)
+    #original_values = copy.deepcopy(state)
+    original_values = deepish_copy(state)
     state.update(kwargs)
+    #if CLEANUP_KEY in state:
+    #    state.update({CLEANUP_KEY: []})
     try:
         yield state
     finally:
+        cleanup(state)
         read_only(state)
         state.clear()
         state.update(original_values)


### PR DESCRIPTION
- [x] child contexts should have access to ssh client objects created by their parents so the connection can be reused
- [x] connections should be cleaned up when a context is left
- [x] children shouldn't cleanup their parent's connections
- [x] review