### PR TITLE
second attempt at addressing multiprocessing + ssh

### DIFF
--- a/example.py
+++ b/example.py
@@ -211,7 +211,7 @@ def mix_match_ssh_clients():
     # single client
     with settings(user='elife', host_string='34.201.187.7', quiet=False, discard_output=False):
         run_a_remote_command() # works
-        check_many_remote_files() # doesn't 
+        check_many_remote_files() # doesn't  # works with monkey_patch 
         run_a_remote_command() # works
 
 def mix_match_ssh_clients2():
@@ -226,7 +226,7 @@ def mix_match_ssh_clients3():
         print('--------2')
         run_a_remote_command() # works
         print('--------3')
-        check_many_remote_files() # doesn't
+        check_many_remote_files() # doesn't # works with monkey_patch
 
 def mix_match_ssh_clients4():
     with settings(user='elife', host_string='34.201.187.7', quiet=False, discard_output=False):
@@ -234,9 +234,6 @@ def mix_match_ssh_clients4():
         check_many_remote_files() # works
 
 def main():
-    mix_match_ssh_clients3()
-    return
-    '''
     nest_some_settings()
     run_a_local_command()
     run_a_local_command_with_separate_streams()
@@ -258,6 +255,6 @@ def main():
         download_file_owned_by_root()
         upload_and_download_a_file_using_bytes()
         check_many_remote_files()
-    '''
+
 if __name__ == '__main__':
     main()

--- a/example.py
+++ b/example.py
@@ -206,9 +206,35 @@ def check_many_remote_files():
 
     print(execute.execute(state.ENV, workerfn, param_key='remote_file', param_values=remote_file_list))
 
-def main():
+
+def mix_match_ssh_clients():
+    # single client
     with settings(user='elife', host_string='34.201.187.7', quiet=False, discard_output=False):
-        check_many_remote_files()
+        run_a_remote_command() # works
+        check_many_remote_files() # doesn't 
+        run_a_remote_command() # works
+
+def mix_match_ssh_clients2():
+    with settings(user='elife', host_string='34.201.187.7', quiet=False, discard_output=False):
+        check_many_remote_files() # works
+        run_a_remote_command() # works
+
+def mix_match_ssh_clients3():
+    with settings(user='elife', host_string='34.201.187.7', quiet=False, discard_output=False):
+        print('--------1')
+        check_many_remote_files() # works
+        print('--------2')
+        run_a_remote_command() # works
+        print('--------3')
+        check_many_remote_files() # doesn't
+
+def mix_match_ssh_clients4():
+    with settings(user='elife', host_string='34.201.187.7', quiet=False, discard_output=False):
+        check_many_remote_files() # works
+        check_many_remote_files() # works
+
+def main():
+    mix_match_ssh_clients3()
     return
     '''
     nest_some_settings()

--- a/example.py
+++ b/example.py
@@ -186,7 +186,7 @@ def check_remote_files():
     assert remote_file_exists(file_that_exists)
     assert not remote_file_exists(file_that_does_not_exist)
 
-def check_many_remote_files():
+def test_check_many_remote_files():
     remote_file_list = [
         '/var/log/syslog', # True, exists
         '/foo/bar'         # False, doesn't exist
@@ -195,43 +195,45 @@ def check_many_remote_files():
     @execute.parallel
     def workerfn():
         with state.settings() as env:
-            remote_file = env['remote_file']
-            print("looking for",remote_file)
-            print("I have the environment",env)
-            try:
-                return remote_file_exists(remote_file, use_sudo=True)
-            except BaseException:
-                import traceback
-                print(traceback.format_exc())
+            return remote_file_exists(env['remote_file'], use_sudo=True)
 
-    print(execute.execute(state.ENV, workerfn, param_key='remote_file', param_values=remote_file_list))
+    expected = [True, False]
+    result = execute.execute(state.ENV, workerfn, param_key='remote_file', param_values=remote_file_list)
+    assert expected == result
 
-
-def mix_match_ssh_clients():
-    # single client
-    with settings(user='elife', host_string='34.201.187.7', quiet=False, discard_output=False):
-        run_a_remote_command() # works
-        check_many_remote_files() # doesn't  # works with monkey_patch 
-        run_a_remote_command() # works
+def mix_match_ssh_clients1():
+    print('--------1-1')
+    run_a_remote_command() # works
+    print('--------1-2')
+    test_check_many_remote_files() # works with monkey_patch 
+    print('--------1-3')
+    run_a_remote_command() # works
 
 def mix_match_ssh_clients2():
-    with settings(user='elife', host_string='34.201.187.7', quiet=False, discard_output=False):
-        check_many_remote_files() # works
-        run_a_remote_command() # works
+    print('--------2-1')
+    test_check_many_remote_files() # works
+    print('--------2-2')
+    run_a_remote_command() # works
 
 def mix_match_ssh_clients3():
-    with settings(user='elife', host_string='34.201.187.7', quiet=False, discard_output=False):
-        print('--------1')
-        check_many_remote_files() # works
-        print('--------2')
-        run_a_remote_command() # works
-        print('--------3')
-        check_many_remote_files() # doesn't # works with monkey_patch
+    print('--------3-1')
+    test_check_many_remote_files() # works
+    print('--------3-2')
+    run_a_remote_command() # works
+    print('--------3-3')
+    test_check_many_remote_files() # works with monkey_patch
 
 def mix_match_ssh_clients4():
-    with settings(user='elife', host_string='34.201.187.7', quiet=False, discard_output=False):
-        check_many_remote_files() # works
-        check_many_remote_files() # works
+    print('--------4-1')
+    test_check_many_remote_files() # works
+    print('--------4-2')
+    test_check_many_remote_files() # works
+
+def mix_match_ssh_clients():
+    mix_match_ssh_clients1()
+    mix_match_ssh_clients2()
+    mix_match_ssh_clients3()
+    mix_match_ssh_clients4()
 
 def main():
     nest_some_settings()
@@ -254,7 +256,9 @@ def main():
         upload_file_to_root_dir()
         download_file_owned_by_root()
         upload_and_download_a_file_using_bytes()
-        check_many_remote_files()
+        test_check_many_remote_files()
+
+        mix_match_ssh_clients()
 
 if __name__ == '__main__':
     main()

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -91,9 +91,9 @@ def test_execute_many_parallel_with_params():
     param_key = 'mykey'
     param_values = [1,2,3]
     
-    expected = [{'parent': 'environment', "mykey": 1},
-                {'parent': 'environment', "mykey": 2},
-                {'parent': 'environment', "mykey": 3}]
+    expected = [{'parallel': True, 'parent': 'environment', "mykey": 1},
+                {'parallel': True, 'parent': 'environment', "mykey": 2},
+                {'parallel': True, 'parent': 'environment', "mykey": 3}]
 
     with settings(parent='environment') as env:
         assert expected == execute.execute(env, parallel_fn, param_key, param_values)
@@ -108,9 +108,9 @@ def test_execute_many_parallel_raw_results():
     param_key = 'mykey'
     param_values = [1, 2, 3]
     expected = [
-        {'name': 'process--1', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parent': 'environment', 'mykey': 1}},
-        {'name': 'process--2', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parent': 'environment', 'mykey': 2}},
-        {'name': 'process--3', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parent': 'environment', 'mykey': 3}}]
+        {'name': 'process--1', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parallel': True, 'parent': 'environment', 'mykey': 1}},
+        {'name': 'process--2', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parallel': True, 'parent': 'environment', 'mykey': 2}},
+        {'name': 'process--3', 'exitcode': 0, 'alive': False, 'killed': False, 'kill-signal': None, 'result': {'parallel': True, 'parent': 'environment', 'mykey': 3}}]
     result_list = execute._parallel_execution(env, parallel_fn, param_key, param_values)
 
     # process pid is available but is not compared during testing. it's non-deterministic

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -1,0 +1,6 @@
+# gevent is used by parallel-ssh which interferes with Python multiprocessing and futures
+# it can cause indefinite blocking.
+# this bit of magic appears to make everything work nicely with each
+# - http://www.gevent.org/api/gevent.monkey.html
+from gevent import monkey
+monkey.patch_all()

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -36,3 +36,56 @@ def rename(d, pair_list):
 def cwd():
     "returns the resolved path to the Current Working Dir (cwd)"
     return os.path.realpath(os.curdir)
+
+# utils
+
+# direct copy from Fabric:
+# https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L33-L46
+# TODO: adjust licence accordingly
+def _shell_escape(string):
+    """
+    Escape double quotes, backticks and dollar signs in given ``string``.
+    For example::
+        >>> _shell_escape('abc$')
+        'abc\\\\$'
+        >>> _shell_escape('"')
+        '\\\\"'
+    """
+    for char in ('"', '$', '`'):
+        string = string.replace(char, r'\%s' % char)
+    return string
+
+# https://github.com/mathiasertl/fabric/blob/master/fabric/state.py#L253-L256
+def shell_wrap_command(command):
+    """wraps the given command in a shell invocation.
+    default shell is /bin/bash (like Fabric)
+    no support for configurable shell at present"""
+
+    # '-l' is 'login' shell
+    # '-c' is 'run command'
+    shell_prefix = "/bin/bash -l -c"
+
+    escaped_command = _shell_escape(command)
+    escaped_wrapped_command = '"%s"' % escaped_command
+
+    space = " "
+    final_command = shell_prefix + space + escaped_wrapped_command
+
+    return final_command
+
+def sudo_wrap_command(command):
+    """adds a 'sudo' prefix to command to run as root. 
+    no support for sudo'ing to configurable users/groups"""
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L605-L623
+    # https://github.com/mathiasertl/fabric/blob/master/fabric/state.py#L374-L376
+    # note: differs from Fabric. they support interactive input of password, users and groups
+    # we use it exclusively to run commands as root
+    sudo_prefix = "sudo --non-interactive"
+    space = " "
+    return sudo_prefix + space + command
+
+def pwd_wrap_command(command, working_dir):
+    "adds a 'cd' prefix to command"
+    prefix = 'cd "%s" &&' % working_dir
+    space = " "
+    return prefix + space + command

--- a/threadbare/execute.py
+++ b/threadbare/execute.py
@@ -73,6 +73,7 @@ def _parallel_execution(env, func, param_key, param_values, return_process_pool=
         #if nth_val: # why was I doing this?
         #    new_env[param_key] = nth_val
         new_env[param_key] = nth_val
+        new_env['parallel'] = True
 
         # lets not set these until we need them:
         # new_env['parallel'] = True

--- a/threadbare/execute.py
+++ b/threadbare/execute.py
@@ -30,7 +30,7 @@ def _parallel_execution_worker_wrapper(env, worker_func, name, queue):
         # implicit `settings() as env` invocation rather than `settings(env)` as we have
         # no reference to `env` unless the worker function accepts it as a parameter.
         # and we can't rely on that.
-        state.ENV = state.LockableDict()
+        state.ENV = state.init_state() #LockableDict() # reset the state
         state.read_write(state.ENV)
         state.ENV.update(env or {})
         result = worker_func()
@@ -72,20 +72,14 @@ def _parallel_execution(env, func, param_key, param_values, return_process_pool=
         kwargs['name'] = 'process--' + str(idx + 1) # process--1, process--2
         new_env = {} if not env else copy.deepcopy(env)
 
-        if 'ssh_client' in new_env:
-            #state.cleanup(new_env) # dont do this, parent may need the connection
-            del new_env['ssh_client']
-
         # ssh clients are not shared between processes
-        #print('new env', new_env)
+        if 'ssh_client' in new_env:
+            del new_env['ssh_client']
 
         new_env[param_key] = nth_val
         new_env['parallel'] = True
-
-        # lets not set these until we need them:
-        # new_env['parallel'] = True
-        # new_env['linewise'] = True
         # https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L223-L227
+        # new_env['linewise'] = True # not set until needed
 
         kwargs['env'] = new_env
         p = Process(name=kwargs['name'], target=_parallel_execution_worker_wrapper, kwargs=kwargs)

--- a/threadbare/operations.py
+++ b/threadbare/operations.py
@@ -10,12 +10,16 @@ import pssh.clients.native
 
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
-
 # gevent is used by Parallel-SSH which interferes with Python multiprocessing
 # it causes 'things' to block indefinitely
+# turns out, gevent and futures and multiprocessing are all troublesome together
+# if this code is executing, it's because a remote command is being executed with multiprocessing
+# TODO: this may not work if you want to run a boto command with multiprocessing
+#from gevent import monkey
+#monkey.patch_all(thread=False)
 from gevent import monkey
-monkey.patch_all(thread=False)
+monkey.patch_all()
+
 
 # socket handling (ssh) behaves differently inside a child process when using multiprocessing
 # pssh.native.parallel.SSHClient handles this well, but the function signatures and return values
@@ -27,16 +31,13 @@ monkey.patch_all(thread=False)
 class SSHClient(object):
     def __init__(self, **kwargs):
         self.parallel = state.ENV.get('parallel', False)
-        self.parallel = True
+        #self.parallel = True # use to switch between ParallelSSHClient and regular SSHClient
 
         if self.parallel:
-            print('creating parallel')
             host = kwargs.pop('host')
             self.host = host
             self.client = pssh.clients.native.parallel.ParallelSSHClient([host], **kwargs)
         else:
-
-            print('creating single')
             self.host = kwargs['host']
             self.client = pssh.clients.native.SSHClient(**kwargs)
 
@@ -52,8 +53,6 @@ class SSHClient(object):
             greenlet_timeout = 10 # seconds #None # = timeout ?
             host_args = None
 
-            print('running command against',self.host,self.client.host_clients)
-            
             result = self.client.run_command(command, sudo, user, stop_on_errors, use_pty,  host_args, shell, encoding, timeout, greenlet_timeout)
             self._last_result = result
 
@@ -89,9 +88,7 @@ class SSHClient(object):
         return channel.get_exit_status()
 
     def disconnect(self):
-        print('disconnecting ...')
         if self.parallel:
-            print(self.client.host_clients)
             if self.host in self.client.host_clients:
                 self.client.host_clients[self.host].disconnect()
             return
@@ -178,7 +175,6 @@ def _ssh_client(**kwargs):
     # if we're not using global state, return the new client as-is
     env = state.ENV
     if env.read_only:
-        print('read-only, retrieving client')
         return SSHClient(**final_kwargs)
 
     client_map_key = "ssh_client"
@@ -189,15 +185,11 @@ def _ssh_client(**kwargs):
     # otherwise, check to see if a previous client is available
     client_map = env.get(client_map_key, {})
     if client_key in client_map:
-        print('retrieving client')
-        result = client_map[client_key]
-        print('got result',result)
-        return result
+        return client_map[client_key]
 
     # if not, create a new one and store it in the state
 
     # https://parallel-ssh.readthedocs.io/en/latest/native_single.html#pssh.clients.native.single.SSHClient
-    print('creating new client')
     client = SSHClient(**final_kwargs)
 
     # disconnect session when leaving context manager

--- a/threadbare/operations.py
+++ b/threadbare/operations.py
@@ -8,60 +8,16 @@ from threadbare import state
 from threadbare.common import merge, subdict, rename, cwd, sudo_wrap_command, pwd_wrap_command, shell_wrap_command
 import pssh.clients.native
 
-import logging
-
-# gevent is used by Parallel-SSH which interferes with Python multiprocessing
-# it causes 'things' to block indefinitely
-# turns out, gevent and futures and multiprocessing are all troublesome together
-# if this code is executing, it's because a remote command is being executed with multiprocessing
-# TODO: this may not work if you want to run a boto command with multiprocessing
-#from gevent import monkey
-#monkey.patch_all(thread=False)
-from gevent import monkey
-monkey.patch_all()
-
-
-# socket handling (ssh) behaves differently inside a child process when using multiprocessing
-# pssh.native.parallel.SSHClient handles this well, but the function signatures and return values
-# and other behaviour changes, like downloading files to something other than what we told it to.
-# it does this because it expects to be handling multiprocessing itself, rather than multiprocessing
-# handled by something else and remote calls being made within it.
-# the below wraps this all up
-
 class SSHClient(object):
     def __init__(self, **kwargs):
-        self.parallel = state.ENV.get('parallel', False)
-        #self.parallel = True # use to switch between ParallelSSHClient and regular SSHClient
+        self.client = pssh.clients.native.SSHClient(**kwargs)
 
-        if self.parallel:
-            host = kwargs.pop('host')
-            self.host = host
-            self.client = pssh.clients.native.parallel.ParallelSSHClient([host], **kwargs)
-        else:
-            self.host = kwargs['host']
-            self.client = pssh.clients.native.SSHClient(**kwargs)
-
-    def run_command(self, command, user, use_pty):
-
-        shell = False
-        sudo = False
-        timeout = None
-        encoding = 'utf-8'
-
-        if self.parallel:
-            stop_on_errors = True,
-            greenlet_timeout = 10 # seconds #None # = timeout ?
-            host_args = None
-
-            result = self.client.run_command(command, sudo, user, stop_on_errors, use_pty,  host_args, shell, encoding, timeout, greenlet_timeout)
-            self._last_result = result
-
-            self.client.join(result)
-            
-            result = result[self.host]
-            # result is a 'HostOutput' object
-            # https://parallel-ssh.readthedocs.io/en/latest/output.html#pssh.output.HostOutput
-            return (result['channel'], result['host'], result['stdout'], result['stderr'], result['stdin'])
+    def run_command(self, command, use_pty):
+        shell = False # handled ourselves
+        sudo = False # handled ourselves
+        timeout = None # TODO
+        encoding = 'utf-8' # used everywhere
+        user = None
 
         # https://parallel-ssh.readthedocs.io/en/latest/native_single.html#pssh.clients.native.single.SSHClient.run_command
         result = self.client.run_command(command, sudo, user, use_pty, shell, encoding, timeout)
@@ -69,30 +25,17 @@ class SSHClient(object):
         return result
 
     def copy_file(self, local_path, remote_path):
-        if self.parallel:
-            raise NotImplementedError('copy_file')
         return self.client.copy_file(local_path, remote_path)
 
     def copy_remote_file(self, remote_path, local_path):
-        if self.parallel:
-            raise NotImplementedError('copy_remote_file')
         return self.client.copy_remote_file(remote_path, local_path)
 
     def get_exit_code(self):
-        if self.parallel:
-            self.client.join(self._last_result)
-            return self._last_result[self.host]['exit_code']
-
         channel = self._last_result[0]
         self.client.wait_finished(channel)
         return channel.get_exit_status()
 
     def disconnect(self):
-        if self.parallel:
-            if self.host in self.client.host_clients:
-                self.client.host_clients[self.host].disconnect()
-            return
-
         return self.client.disconnect()
 
     def __deepcopy__(self, memo):
@@ -178,7 +121,6 @@ def _ssh_client(**kwargs):
         return SSHClient(**final_kwargs)
 
     client_map_key = "ssh_client"
-    #client_key = tuple(sorted(final_kwargs.items()))
     client_key = subdict(final_kwargs, ['user', 'host', 'pkey', 'port', 'timeout'])
     client_key = tuple(sorted(client_key.items()))
     
@@ -205,16 +147,16 @@ def _execute(command, user, key_filename, host_string, port, use_pty):
     client = _ssh_client(user=user, host_string=host_string, key_filename=key_filename, port=port)
     
     try:
-        channel, host_string, stdout, stderr, stdin = client.run_command(command, user, use_pty) #, encoding, timeout)
+        channel, host_string, stdout, stderr, stdin = client.run_command(command, use_pty) #, encoding, timeout)
 
         return {
-            'return_code': client.get_exit_code(),
+            'return_code': client.get_exit_code,
             'command': command,
             'stdout': stdout,
             'stderr': stderr,
         }
     except BaseException as ex:
-        # *most likely* a network error:
+        # *probably* a network error:
         # https://github.com/ParallelSSH/parallel-ssh/blob/master/pssh/exceptions.py
         raise NetworkError(ex)
 
@@ -309,7 +251,7 @@ def remote(command, **kwargs):
         'stderr': _process_output(sys.stderr, result['stderr'], **output_kwargs),
 
         # command must have finished before we have access to return code
-        'return_code': result['return_code'] #(), 
+        'return_code': result['return_code'](), 
     })
 
     return result

--- a/threadbare/state.py
+++ b/threadbare/state.py
@@ -29,8 +29,12 @@ def read_write(d):
     if hasattr(d, 'read_only'):
         d.read_only = False
 
-ENV = LockableDict()
-read_only(ENV)
+def init_state():
+    new_env = LockableDict()
+    read_only(new_env)
+    return new_env
+        
+ENV = init_state()
 
 # used to determine how deeply nested we are
 DEPTH = 0


### PR DESCRIPTION
this fix pushes the inconsistencies between the SSHClient and ParallelSSHClient into our client object with function signatures and behaviour that matches the single client.

this means that for most things, the simpler-to-reason-about SSHClient is used. when used in parallel, the arguments and results are interpolated behind the scenes

- [x] review