### PR TITLE
feature: abort_on_prompts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,13 +39,12 @@
     - you would think this would abort if a prompt was issued, which is *technically* correct, but only for certain 
     defintions of 'prompt'
     - it will abort if *Fabric* issues the prompt, but not if *you* issue a command that requires a prompt
-        - for example:
+        - for example, this will **not** abort:
         
-
+```
     with settings(abort_on_prompt=True):
         local("read -p '> '")
-        
-    - will **not** abort
+```
 
 * SFTP (default for pssh and fabric) is excruciatingly slow
     - can we safely switch to SCP?

--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@
 - [x] implement 'timeout'
 - [ ] implement 'abort_on_prompts', bails when ~input on stdin is requested~ *Fabric* issues a prompt
 - [ ] implement 'abort_exception', the exception to raise when execution is aborted
+- [ ] implement 'warn_only', "warn, instead of abort, when commands fail", used in masterless when updating repos
 - [x] implement `quiet=True` in `local` and `remote`
 - [x] implement ssh session sharing so multiple commands can be run
 - [x] output is being duplicated, once from logging, once from us. what does builder do?

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@
 - [x] implement `rcd`
 - [x] use the `hosts` in the environment to determine `param_key` and `param_values` parameters to `execute`
 - [x] implement 'timeout'
-- [ ] implement 'abort_on_prompts', bails when input on stdin is requested
+- [ ] implement 'abort_on_prompts', bails when ~input on stdin is requested~ *Fabric* issues a prompt
 - [ ] implement 'abort_exception', the exception to raise when execution is aborted
 - [x] implement ssh session sharing so multiple commands can be run
 - [ ] output is being duplicated, once from logging, once from us. what does builder do?
@@ -34,8 +34,18 @@
 
 ## investigate:
 
-* `remote_file_exists` needs it's behaviour checked against what Fabric is doing
-    - it's causing bootstrap to fail/hang while polling for remote files
+* `abort_on_prompts=True`
+    - https://github.com/mathiasertl/fabric/blob/19c9f3fcf22e384fe2a6127ea9c268a3a4ff8a6b/fabric/network.py#L446
+    - you would think this would abort if a prompt was issued, which is *technically* correct, but only for certain 
+    defintions of 'prompt'
+    - it will abort if *Fabric* issues the prompt, but not if *you* issue a command that requires a prompt
+        - for example:
+        
+
+    with settings(abort_on_prompt=True):
+        local("read -p '> '")
+        
+    - will **not** abort
 
 * SFTP (default for pssh and fabric) is excruciatingly slow
     - can we safely switch to SCP?
@@ -51,11 +61,13 @@
     - not used explicitly in builder
     - prints contents per-line rather than per-chunk-of-bytes
 
+
+## wontfix:
+
 * are we using upload/download on directories of files? 
     - because Fabric and pssh totally support that.
         - they're both using SFTP under the hood
-
-## wontfix:
+    - we're not. support for uploading/download directories is disabled
 
 * implement `disconnect_all` that closes all open client connections
     - client connections are closed automatically when the context is left

--- a/TODO.md
+++ b/TODO.md
@@ -42,7 +42,7 @@
         - for example, this will **not** abort:
         
 ```
-    with settings(abort_on_prompt=True):
+    with settings(abort_on_prompts=True):
         local("read -p '> '")
 ```
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -303,3 +303,20 @@ def test_execute_with_prompts_custom():
         results = execute.execute({}, workerfn)
         expected = str(ValueError("prompted with: gimmie"))
         assert expected == str(results[0])
+
+
+def test_execute_with_prompts_override():
+    """prompts issued while executing a worker function in parallel that has set 
+    their `abort_on_prompts` to `False` will get the unsupported `EOFError` raised"""
+
+    @execute.parallel
+    def workerfn():
+        with settings(abort_on_prompts=False):
+            return operations.prompt("gimmie")
+
+    results = execute.execute({}, workerfn)
+
+    # this is what Python will give you
+    expected = EOFError("EOF when reading a line")
+
+    assert str(expected) == str(results[0])

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,6 +1,6 @@
 import pytest
 import time
-from threadbare import execute, state
+from threadbare import execute, state, operations
 from threadbare.state import settings
 
 
@@ -132,9 +132,24 @@ def test_execute_many_parallel_with_params():
     param_values = [1, 2, 3]
 
     expected = [
-        {"parallel": True, "parent": "environment", "mykey": 1},
-        {"parallel": True, "parent": "environment", "mykey": 2},
-        {"parallel": True, "parent": "environment", "mykey": 3},
+        {
+            "parallel": True,
+            "abort_on_prompts": True,
+            "parent": "environment",
+            "mykey": 1,
+        },
+        {
+            "parallel": True,
+            "abort_on_prompts": True,
+            "parent": "environment",
+            "mykey": 2,
+        },
+        {
+            "parallel": True,
+            "abort_on_prompts": True,
+            "parent": "environment",
+            "mykey": 3,
+        },
     ]
 
     with settings(parent="environment") as env:
@@ -159,7 +174,12 @@ def test_execute_many_parallel_raw_results():
             "alive": False,
             "killed": False,
             "kill-signal": None,
-            "result": {"parallel": True, "parent": "environment", "mykey": 1},
+            "result": {
+                "parallel": True,
+                "abort_on_prompts": True,
+                "parent": "environment",
+                "mykey": 1,
+            },
         },
         {
             "name": "process--2",
@@ -167,7 +187,12 @@ def test_execute_many_parallel_raw_results():
             "alive": False,
             "killed": False,
             "kill-signal": None,
-            "result": {"parallel": True, "parent": "environment", "mykey": 2},
+            "result": {
+                "parallel": True,
+                "abort_on_prompts": True,
+                "parent": "environment",
+                "mykey": 2,
+            },
         },
         {
             "name": "process--3",
@@ -175,7 +200,12 @@ def test_execute_many_parallel_raw_results():
             "alive": False,
             "killed": False,
             "kill-signal": None,
-            "result": {"parallel": True, "parent": "environment", "mykey": 3},
+            "result": {
+                "parallel": True,
+                "abort_on_prompts": True,
+                "parent": "environment",
+                "mykey": 3,
+            },
         },
     ]
     result_list = execute._parallel_execution(env, parallel_fn, param_key, param_values)
@@ -247,3 +277,24 @@ def test_execute_with_hosts():
     results = execute.execute_with_hosts(env, workerfn, hosts)
     expected = {"local": "localhost", "good": "goodhost"}
     assert expected == results
+
+
+def test_execute_with_prompts():
+    @execute.parallel
+    def workerfn():
+        return operations.prompt("gimmie")
+
+    results = execute.execute({}, workerfn)
+    expected = str(operations.PromptedException("prompted with: gimmie"))
+    assert expected == str(results[0])
+
+def test_execute_with_prompts_custom():
+    @execute.parallel
+    def workerfn():
+        return operations.prompt("gimmie")
+
+    with settings(abort_exception=ValueError):
+        results = execute.execute({}, workerfn)
+        expected = str(ValueError("prompted with: gimmie"))
+        assert expected == str(results[0])
+    

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -2,6 +2,7 @@ import pytest
 import time
 from threadbare import execute, state, operations
 from threadbare.state import settings
+from threadbare.common import PromptedException
 
 
 def test_parallel_wrapper():
@@ -280,15 +281,20 @@ def test_execute_with_hosts():
 
 
 def test_execute_with_prompts():
+    "prompts issued while executing a worker function in parallel return the PromptedException"
+
     @execute.parallel
     def workerfn():
         return operations.prompt("gimmie")
 
     results = execute.execute({}, workerfn)
-    expected = str(operations.PromptedException("prompted with: gimmie"))
+    expected = str(PromptedException("prompted with: gimmie"))
     assert expected == str(results[0])
 
+
 def test_execute_with_prompts_custom():
+    "prompts issued while executing a worker function in parallel with `abort_exception` return a custom exception"
+
     @execute.parallel
     def workerfn():
         return operations.prompt("gimmie")
@@ -297,4 +303,3 @@ def test_execute_with_prompts_custom():
         results = execute.execute({}, workerfn)
         expected = str(ValueError("prompted with: gimmie"))
         assert expected == str(results[0])
-    

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -8,7 +8,7 @@ except ImportError:
     from mock import patch
 
 from threadbare import operations, state
-from threadbare.common import merge, cwd
+from threadbare.common import merge, cwd, PromptedException
 from pssh import exceptions as pssh_exceptions
 
 # remote
@@ -410,12 +410,14 @@ def test_single_command():
 
 
 def test_prompt_operation_aborted():
+    "calling `prompt` for user input with `abort_on_prompts=True` set raises an exception"
     with state.settings(abort_on_prompts=True):
-        with pytest.raises(operations.PromptedException):
+        with pytest.raises(PromptedException):
             operations.prompt("some message")
 
 
 def test_prompt_operation_aborted_custom_exception():
+    "calling `prompt` for user input with `abort_on_prompts=True` and `abort_exception` set raises a custom exception"
     with state.settings(abort_on_prompts=True, abort_exception=ValueError):
         with pytest.raises(ValueError):
             operations.prompt("some message")

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -407,3 +407,15 @@ def test_single_command():
     for given, expected in cases:
         actual = operations.single_command(given)
         assert expected == actual, "failed case. %r != %r" % (expected, actual)
+
+
+def test_prompt_operation_aborted():
+    with state.settings(abort_on_prompts=True):
+        with pytest.raises(operations.PromptedException):
+            operations.prompt("some message")
+
+
+def test_prompt_operation_aborted_custom_exception():
+    with state.settings(abort_on_prompts=True, abort_exception=ValueError):
+        with pytest.raises(ValueError):
+            operations.prompt("some message")

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -7,10 +7,6 @@ from gevent import monkey
 monkey.patch_all()
 
 
-class PromptedException(BaseException):
-    pass
-
-
 from . import state, operations, execute
 
 assert state and operations and execute  # quieten pyflakes

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -6,6 +6,11 @@ from gevent import monkey
 
 monkey.patch_all()
 
+
+class PromptedException(BaseException):
+    pass
+
+
 from . import state, operations, execute
 
 assert state and operations and execute  # quieten pyflakes

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -2,6 +2,10 @@ import os
 from functools import reduce
 
 
+class PromptedException(BaseException):
+    pass
+
+
 def first(x):
     "returns the first element in an collection of things"
     if x is None:

--- a/threadbare/execute.py
+++ b/threadbare/execute.py
@@ -39,7 +39,7 @@ def _parallel_execution_worker_wrapper(env, worker_func, name, queue):
         state.ENV = state.init_state()
         state.read_write(state.ENV)
         state.ENV.update(env or {})
-        # not possible to service stdin when multiprocessing
+        # note: not possible to service stdin when multiprocessing
         state.ENV["abort_on_prompts"] = True
         result = worker_func()
         queue.put({"name": name, "result": result})

--- a/threadbare/execute.py
+++ b/threadbare/execute.py
@@ -39,6 +39,8 @@ def _parallel_execution_worker_wrapper(env, worker_func, name, queue):
         state.ENV = state.init_state()
         state.read_write(state.ENV)
         state.ENV.update(env or {})
+        # not possible to service stdin when multiprocessing
+        state.ENV["abort_on_prompts"] = True
         result = worker_func()
         queue.put({"name": name, "result": result})
     except BaseException as unhandled_exception:

--- a/threadbare/operations.py
+++ b/threadbare/operations.py
@@ -2,12 +2,12 @@ import tempfile
 import contextlib
 import subprocess
 from threading import Timer
-from threadbare import PromptedException
 import getpass
 from pssh import exceptions as pssh_exceptions
 import os, sys
 from . import state
 from .common import (
+    PromptedException,
     merge,
     subdict,
     rename,

--- a/threadbare/operations.py
+++ b/threadbare/operations.py
@@ -2,6 +2,7 @@ import tempfile
 import contextlib
 import subprocess
 from threading import Timer
+from threadbare import PromptedException
 import getpass
 from pssh import exceptions as pssh_exceptions
 import os, sys
@@ -381,6 +382,21 @@ def single_command(cmd_list):
     if cmd_list in [None, []]:
         return None
     return " && ".join(map(str, cmd_list))
+
+
+def prompt(msg):
+    """issues a prompt for input. 
+    raises a PromptedException if `abort_on_prompts` in `state.ENV` is `True` or executing within 
+    another process using `execute.parallel` where input can't be supplied.
+    if `abort_exception` is set in `state.ENV`, then that exception is raised instead"""
+    if state.ENV.get("abort_on_prompts", False):
+        abort_ex = state.ENV.get("abort_exception", PromptedException)
+        raise abort_ex("prompted with: %s" % (msg,))
+    print(msg)
+    try:
+        return raw_input("> ")
+    except NameError:
+        return input("> ")
 
 
 # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L419


### PR DESCRIPTION
- [integration tests](https://github.com/elifesciences/builder/blob/a4892ab315ee6c2684bb0235b61510c59f305aed/src/integration_tests/test_provisioning.py#L38)
- [test base](https://github.com/elifesciences/builder/blob/a4892ab315ee6c2684bb0235b61510c59f305aed/src/tests/base.py#L122)
- [running remote commands](https://github.com/elifesciences/builder/blob/c66a1d38192028848ed363805127570bc9d87f56/src/cfn.py#L349)

---

* updated TODO with explanation of 'abort_on_prompts'