### PR TITLE
1.0 prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Global state can be built up by nesting context managers like `settings` or `hid
 environment dictionary, and then popping it off as execution leaves the context manager.
 
 The `state` module replicates this mechanism but with no initial defaults. Default values are pushed back into the 
-functions and may be overridden globally in a general way or overridden specifically by passing in a keyword argument.
+functions and may be overridden globally in a general way or overridden specifically by passing in a keyword argument to
+the function.
 
 This change:
 
@@ -120,5 +121,5 @@ mechanism for manipulating global state.
 * changes to global state within the worker function does not propagate back to the parent
 * SSH connections cannot be passed to child processes so new connections are made within the child process if necessary
 * child processes cannot prompt for input. They have no access to stdin.
-* child processes may die or throw exceptions that can't be properly
+* child processes may die or throw exceptions that can't be properly handled in the parent
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
-# threadbare
+# Threadbare
 
 A partial replacement for the slice of Fabric 1.x and Paramiko used in [Builder](https://github.com/elifesciences/builder)
 
-See [TODO.md](./TODO.md) for what remains to be implemented for the first stable release.
+## usage
+
+Threadbare can be used like this:
+
+```python
+import threadbare
+threadbare.operations.remote("echo 'hello world!'", host_string='my.server', warn_only=True)
+```
+
+or like this:
+
+```python
+from threadbare.state import settings
+from threadbare.operations import remote
+with settings(host_string='my.server', warn_only=True):
+    remote("echo 'hello world!'")
+```
+
+## local tests
 
 Run the [test suite](./test.sh) with `./test.sh`
 
@@ -27,3 +45,80 @@ The dummy ssh server creates the temporary directory `/tmp/sshd-dummy` and write
 The only user that may connect to this dummy SSH server is the current user using the certificate generated for them.
 
 See `./tests-remote/ssh-client.sh` for a working example on connecting to the dummy SSH server.
+
+## local+remote tests
+
+This runs a dummy ssh server and runs both the local unit tests as well as the remote
+tests. It's used in CI and generates a set of temporary credentials with deliberately 
+insecure ssh configuration. Be cautious.
+
+    ./project_tests.sh
+
+# a guide to Threadbare for developers
+
+Threadbare is comprised of just three modules:
+
+1. `state`
+2. `operations`
+3. `execute`
+
+## state
+
+([source](https://github.com/elifesciences/threadbare/blob/develop/threadbare/state.py))
+
+Underpinning all of Fabric is it's manipulation of a global state dictionary called the 'environment'.
+
+For the most part this manipulation is sane, *single threaded* and predictable.
+
+It has many defaults and functions will dip into the environment dictionary and pull out settings as they need them.
+
+Global state can be built up by nesting context managers like `settings` or `hide` or `lcd`, pushing new state into the
+environment dictionary, and then popping it off as execution leaves the context manager.
+
+The `state` module replicates this mechanism but with no initial defaults. Default values are pushed back into the 
+functions and may be overridden globally in a general way or overridden specifically by passing in a keyword argument.
+
+This change:
+
+* improves locality of reference. All options that a function operates on are defined right there with the function.
+* keeps the `state` module small and dumb and predictable
+
+## operations
+
+([source](https://github.com/elifesciences/threadbare/blob/develop/threadbare/operations.py))
+
+Fabric provides a set of very useful commands, like `local` or `sudo` or `cd`.
+
+The `operations` module re-implements these commands and they make heavy use of the `state` module.
+
+Not all commands have been re-implemented, just those in use by Builder.
+
+A big part of the `operations` module is running commands on a remote host. Where Fabric uses it's sister project 
+Paramiko, Threadbare uses a library called PSSH, or ParallelSSH. ParallelSSH itself wraps another project of theirs 
+called `ssh-python`, an interface between `libssh` and Python. ParallelSSH does a little more than just wrap 
+`ssh-python`, it also provides a higher level (and more convenient) interface to basic network operations and ensures
+thread safety.
+
+Threadbare does *not* use the parallel capabilities of ParallelSSH. See `execute`.
+
+## execute
+
+([source](https://github.com/elifesciences/threadbare/blob/develop/threadbare/execute.py))
+
+Fabric provides an interface for running commands in parallel using their global state manipulation mechanism and set of
+operations. It uses Python's `multiprocessing` module.
+
+Threadbare re-implements this mechanism in `execute`, also using `multiprocessing`.
+
+In Fabric the parallelism is used primarily to execute commands on multiple hosts simultaneously, so the interfaces are
+skewed towards that. Threadbare is more general purpose but provides the function `execute_with_hosts` that behaves as 
+Fabric's `execute` does.
+
+Both Threadbare and Fabric share the same caveats of running code in different processes using `multiprocessing` with a
+mechanism for manipulating global state. 
+
+* changes to global state within the worker function does not propagate back to the parent
+* SSH connections cannot be passed to child processes so new connections are made within the child process if necessary
+* child processes cannot prompt for input. They have no access to stdin.
+* child processes may die or throw exceptions that can't be properly
+

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@
 - [x] output is being duplicated, once from logging, once from us. what does builder do?
 - [x] separate development dependencies from required ones
 - [x] test against local sshd server
-- [ ] test automation
+- [x] test automation
 - [x] python 2 tests
 - [x] python 3 tests
 - [x] integrate with builder
@@ -36,6 +36,8 @@
 ## TODO bucket
 
 - [ ] move taskrunner from builder into threadbare, including tests
+- [ ] SFTP is excrutiatingly slow. Can we switch to SCP?
+    - This is not a Fabric/Threadbare/Paramiko/ParallelSSH problem but a SSH/SFTP problem.
 
 ## investigate:
 
@@ -47,14 +49,11 @@
     defintions of 'prompt'
     - it will abort if *Fabric* issues the prompt, but not if *you* issue a command that requires a prompt
         - for example, this will **not** abort:
-        
+
 ```
     with settings(abort_on_prompts=True):
         local("read -p '> '")
 ```
-
-* SFTP (default for pssh and fabric) is excruciatingly slow
-    - can we safely switch to SCP?
 
 * env `linewise`
     - used in `get`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 parallel-ssh
 pytest
 pytest-cov
-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 parallel-ssh
 pytest
 pytest-cov
+six

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -61,7 +61,8 @@ def test__shell_escape():
 
 
 def test__shell_escape_bad_cases():
-    bad_types = [[None, TypeError], [b"", TypeError]]
+    # [b"", TypeError]] # b-strings are strings in py2
+    bad_types = [[None, TypeError]]
     for given, expected in bad_types:
         with pytest.raises(expected):
             common._shell_escape(given)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -51,3 +51,17 @@ def test_subdict():
     for d, key_list, expected in cases:
         actual = common.subdict(d, key_list)
         assert expected == actual
+
+
+def test__shell_escape():
+    cases = [["", ""], ["$abc", "\\$abc"], ['"', '\\"'], ["`", "\\`"]]
+    for given, expected in cases:
+        actual = common._shell_escape(given)
+        assert expected == actual
+
+
+def test__shell_escape_bad_cases():
+    bad_types = [[None, TypeError], [b"", TypeError]]
+    for given, expected in bad_types:
+        with pytest.raises(expected):
+            common._shell_escape(given)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,4 @@
+import pytest
 from threadbare import common
 
 
@@ -7,15 +8,23 @@ def test_first():
         ["", None],
         [[], None],
         [(), None],
-        [{}, None],
         ["abc", "a"],
         [[1, 2, 3], 1],
         [(3, 2, 1), 3],
-        [{1: 2}, (1, 2)],  # non-deterministic in most versions of python, don't do this
     ]
     for given, expected in cases:
         actual = common.first(given)
         assert expected == actual, "failed on case: %r => %r" % (expected, actual)
+
+
+def test_first_bad_cases():
+    dict_cases = [
+        {},
+        {1: 2},  # non-deterministic in all versions of python prior to 3.7
+    ]
+    for case in dict_cases:
+        with pytest.raises(KeyError):
+            common.first(case)
 
 
 def test_merge():

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -65,7 +65,7 @@ def test_global_deleted_state():
 @reset
 def test_uncontrolled_global_state_modification():
     "modifications to global state outside of a context manager are prohibited"
-    assert isinstance(state.ENV, state.LockableDict)  # type check
+    assert isinstance(state.ENV, state.FreezeableDict)  # type check
     assert state.ENV == {}  # empty value
     with pytest.raises(ValueError):
         state.ENV["foo"] = "bar"
@@ -75,7 +75,7 @@ def test_uncontrolled_global_state_modification():
 def test_uncontrolled_global_state_modification_2():
     """modifications to global state that happen outside of the context manager's 
     control (with ... as ...) are available as expected BUT are reverted on exit"""
-    assert isinstance(state.ENV, state.LockableDict)
+    assert isinstance(state.ENV, state.FreezeableDict)
     assert state.ENV == {}
     with settings() as env:
         state.ENV["foo"] = {"bar": "bop"}
@@ -86,11 +86,11 @@ def test_uncontrolled_global_state_modification_2():
 @reset
 def test_uncontrolled_global_state_modification_3():
     "modifications to global state outside of a context manager are prohibited UNLESS you're using own dictionary-like state object"
-    assert isinstance(state.ENV, state.LockableDict)
+    assert isinstance(state.ENV, state.FreezeableDict)
     assert state.ENV == {}
 
     state.ENV = {}
-    assert not isinstance(state.ENV, state.LockableDict)
+    assert not isinstance(state.ENV, state.FreezeableDict)
 
     # ENV is now a regular dictionary
 
@@ -101,7 +101,7 @@ def test_uncontrolled_global_state_modification_3():
 @reset
 def test_global_state_is_unlocked_inside_context():
     "`state.ENV` is only writeable within the context manager"
-    assert isinstance(state.ENV, state.LockableDict)
+    assert isinstance(state.ENV, state.FreezeableDict)
     assert state.ENV.read_only
     with settings():
         assert not state.ENV.read_only
@@ -113,7 +113,7 @@ def test_global_state_is_unlocked_inside_context():
 @reset
 def test_nested_global_state_is_unlocked_inside_context():
     "`state.ENV` is only writeable within the context manager, including nested context managers"
-    assert isinstance(state.ENV, state.LockableDict)
+    assert isinstance(state.ENV, state.FreezeableDict)
     assert state.ENV.read_only
     with settings():
         assert not state.ENV.read_only
@@ -131,7 +131,7 @@ def test_nested_global_state_is_unlocked_inside_context():
 @reset
 def test_lockable_dict():
     "a lockable dictionary has a simple locked/unlocked boolean preventing write access. default is unlocked"
-    foo = state.LockableDict()
+    foo = state.FreezeableDict()
     assert not foo.read_only
 
     state.read_only(foo)
@@ -143,8 +143,8 @@ def test_lockable_dict():
 
 @reset
 def test_lockable_dict_attrs_preserved():
-    "creating a copy of a LockableDict objects preserves the state of the locked/unlocked boolean"
-    foo = state.LockableDict()
+    "creating a copy of a FreezeableDict objects preserves the state of the locked/unlocked boolean"
+    foo = state.FreezeableDict()
     assert not foo.read_only
 
     state.read_only(foo)  # alter foo
@@ -152,7 +152,7 @@ def test_lockable_dict_attrs_preserved():
 
     baz = copy.deepcopy(foo)  # happens when we context shift
     assert baz.read_only
-    assert isinstance(baz, state.LockableDict)
+    assert isinstance(baz, state.FreezeableDict)
 
 
 # cleanup
@@ -200,9 +200,9 @@ def test_set_defaults():
     state.set_defaults({"foo": "bar"})
     assert state.DEPTH == 0
 
-    expected_state = state.LockableDict({"foo": "bar"})
+    expected_state = state.FreezeableDict({"foo": "bar"})
     assert state.ENV == expected_state
-    assert isinstance(state.ENV, state.LockableDict)
+    assert isinstance(state.ENV, state.FreezeableDict)
     assert state.ENV.read_only
 
 

--- a/threadbare/__init__.py
+++ b/threadbare/__init__.py
@@ -1,6 +1,6 @@
 # gevent is used by parallel-ssh which interferes with Python multiprocessing and futures
 # it can cause indefinite blocking.
-# this bit of magic appears to make everything work nicely with each
+# this bit of magic appears to make everything work nicely with each other.
 # - http://www.gevent.org/api/gevent.monkey.html
 from gevent import monkey
 

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -9,12 +9,12 @@ class PromptedException(BaseException):
 def has_type(x, t, msg=None):
     "raises TypeError if given `x` is not of type `t`"
 
-    PY3 = sys.version_info[0] == 3
+    PY2 = sys.version_info[0] == 2
 
-    if PY3:
-        string_types = str
-    else:
+    if PY2:
         string_types = basestring
+    else:
+        string_types = str
 
     msg = msg or "%r is not of expected type %r" % (x, t)
     if t == str and not isinstance(x, string_types):

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -11,11 +11,11 @@ def first(x):
     if x is None:
         return x
     try:
-        if isinstance(x, dict):
-            return list(x.items())[0]
         return x[0]
-    except (ValueError, IndexError):
+    except IndexError:
         return None
+    except (ValueError, KeyError):
+        raise
 
 
 def merge(*dict_list):

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -1,5 +1,4 @@
-import six
-import os
+import os, sys
 from functools import reduce
 
 
@@ -9,8 +8,16 @@ class PromptedException(BaseException):
 
 def has_type(x, t, msg=None):
     "raises TypeError if given `x` is not of type `t`"
+
+    PY3 = sys.version_info[0] == 3
+
+    if PY3:
+        string_types = str
+    else:
+        string_types = basestring
+
     msg = msg or "%r is not of expected type %r" % (x, t)
-    if t == str and not isinstance(x, six.string_types):
+    if t == str and not isinstance(x, string_types):
         raise TypeError(msg)
 
     if not isinstance(x, t):

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -6,6 +6,20 @@ class PromptedException(BaseException):
     pass
 
 
+def has_type(x, t, msg=None):
+    "raises TypeError if given `x` is not of type `t`"
+    if not isinstance(x, t):
+        msg = msg or "%r is not of expected type %r" % (x, t)
+        raise TypeError(msg)
+
+
+def all_have_type(pair_list, msg=None):
+    "raises TypeError if any x in pair (x, t) in `pair_list` is not of type `t`"
+    has_type(pair_list, list)
+    for x, t in pair_list:
+        has_type(x, t, msg)
+
+
 def first(x):
     "returns the first element in an collection of things"
     if x is None:
@@ -63,6 +77,9 @@ def _shell_escape(string):
         >>> _shell_escape('"')
         '\\\\"'
     """
+
+    has_type(string, str)
+
     for char in ('"', "$", "`"):
         string = string.replace(char, r"\%s" % char)
     return string
@@ -73,6 +90,8 @@ def shell_wrap_command(command):
     """wraps the given command in a shell invocation.
     default shell is /bin/bash (like Fabric)
     no support for configurable shell at present"""
+
+    has_type(command, str)
 
     # '-l' is 'login' shell
     # '-c' is 'run command'
@@ -94,13 +113,19 @@ def sudo_wrap_command(command):
     # https://github.com/mathiasertl/fabric/blob/master/fabric/state.py#L374-L376
     # note: differs from Fabric. they support interactive input of password, users and groups
     # we use it exclusively to run commands as root
+
+    has_type(command, str)
+
     sudo_prefix = "sudo --non-interactive"
     space = " "
     return sudo_prefix + space + command
 
 
-def pwd_wrap_command(command, working_dir):
+def cwd_wrap_command(command, working_dir):
     "adds a 'cd' prefix to command"
+
+    all_have_type([(command, str), (working_dir, str)])
+
     prefix = 'cd "%s" &&' % working_dir
     space = " "
     return prefix + space + command

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -1,3 +1,4 @@
+import six
 import os
 from functools import reduce
 
@@ -8,8 +9,11 @@ class PromptedException(BaseException):
 
 def has_type(x, t, msg=None):
     "raises TypeError if given `x` is not of type `t`"
+    msg = msg or "%r is not of expected type %r" % (x, t)
+    if t == str and not isinstance(x, six.string_types):
+        raise TypeError(msg)
+
     if not isinstance(x, t):
-        msg = msg or "%r is not of expected type %r" % (x, t)
         raise TypeError(msg)
 
 

--- a/threadbare/common.py
+++ b/threadbare/common.py
@@ -110,5 +110,5 @@ def isint(x):
     try:
         int(x)
         return True
-    except:
+    except BaseException:
         return False

--- a/threadbare/execute.py
+++ b/threadbare/execute.py
@@ -5,6 +5,7 @@ from .common import first
 from . import state
 
 
+# https://github.com/mathiasertl/fabric/blob/master/fabric/decorators.py#L148-L161
 def serial(func, pool_size=None):
     """Forces the given function to run `pool_size` times.
     when pool_size is None (default), executor decides how many instances of `func` to execute (1, probably).
@@ -17,10 +18,9 @@ def serial(func, pool_size=None):
     return inner
 
 
+# https://github.com/mathiasertl/fabric/blob/master/fabric/decorators.py#L164-L194
 def parallel(func, pool_size=None):
-    """Forces the wrapped function to run in parallel, instead of sequentially.
-    This is an opportunity for pre/post process work prior to calling a function in parallel."""
-    # https://github.com/mathiasertl/fabric/blob/master/fabric/decorators.py#L164-L194
+    """Forces the wrapped function to run in parallel, instead of sequentially."""
     wrapped_func = serial(func, pool_size)
     # `func` *must* be forced to run in parallel to main process
     wrapped_func.parallel = True
@@ -28,7 +28,7 @@ def parallel(func, pool_size=None):
 
 
 def _parallel_execution_worker_wrapper(env, worker_func, name, queue):
-    """this function is executed in another process. it wraps the given `worker_func`, initialising the `state.ENV` of 
+    """this function is executed in another process. it wraps the given `worker_func`, initialising the `state.ENV` of
     the new process and adds its results to the given `queue`"""
     try:
         assert isinstance(env, dict), "given environment must be a dictionary"
@@ -151,7 +151,6 @@ def _serial_execution(func, param_key, param_values):
     result_list = []
     if param_key and param_values:
         for x in param_values:
-            # TODO: this prevent ssh clients from being shared
             with state.settings(**{param_key: x}):
                 result_list.append(func())
     else:
@@ -177,12 +176,12 @@ def execute(func, param_key=None, param_values=None):
     parent process blocks until all child processes have completed.
     returns a map of execution data with the return values of the individual executions available under 'result'"""
 
-    # in Fabric, `execute` is a guard-type function that ensures the function and the function's environment is correct
-    # before passing it to `_execute` that does the actual magic.
+    # in Fabric, `execute` is a guard-type function that ensures the function and the function's environment is
+    # correct before passing it to `_execute` that does the actual magic.
     # `execute`: https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L372-L401
     # `_execute`: https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L213-L277
 
-    # the custom 'JobQueue' adds complexity but can be avoided (I hope):
+    # Fabric's custom 'JobQueue' adds complexity but can be avoided:
     # https://github.com/mathiasertl/fabric/blob/master/fabric/job_queue.py
 
     if (param_key and param_values is None) or (param_key is None and param_values):

--- a/threadbare/execute.py
+++ b/threadbare/execute.py
@@ -125,6 +125,7 @@ def _parallel_execution(env, func, param_key, param_values, return_process_pool=
             if not result["alive"]:
                 result_map[result["name"]] = result
                 del pool[idx]
+        # introduces the slightest of delays so that we're not manically polling every microsecond
         time.sleep(0.1)
 
     # all processes are complete

--- a/threadbare/execute.py
+++ b/threadbare/execute.py
@@ -33,19 +33,14 @@ def _parallel_execution_worker_wrapper(env, worker_func, name, queue):
     try:
         assert isinstance(env, dict), "given environment must be a dictionary"
 
-        # Fabric is nuking the child process's env dictionary
-        # https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L229-L237
-
-        # what we can do is say that worker functions executed in parallel must use the
-        # implicit `settings() as env` invocation rather than `settings(env)` as we have
-        # no reference to `env` unless the worker function accepts it as a parameter.
-        # and we can't rely on that.
+        # Fabric nukes the child process's `env` dictionary
+        # - https://github.com/mathiasertl/fabric/blob/master/fabric/tasks.py#L229-L237
 
         # note: not possible to service stdin when multiprocessing
         env["abort_on_prompts"] = True
 
-        # we don't care what the parent process had when Python copied across it's state
-        # to execute this worker_func in parallel. reset it now. the process is destroyed upon leaving.
+        # we don't care what the parent process had when Python copied across it's state to
+        # execute this `worker_func` in parallel. reset it now. the process is destroyed upon leaving.
 
         state.DEPTH = 0
         state.set_defaults(env)

--- a/threadbare/operations.py
+++ b/threadbare/operations.py
@@ -13,7 +13,7 @@ from .common import (
     rename,
     cwd,
     sudo_wrap_command,
-    pwd_wrap_command,
+    cwd_wrap_command,
     shell_wrap_command,
 )
 from pssh.clients.native import SSHClient as PSSHClient
@@ -257,7 +257,7 @@ def remote(command, **kwargs):
     # wrap the command up
     # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L920-L925
     if final_kwargs["remote_working_dir"]:
-        command = pwd_wrap_command(command, final_kwargs["remote_working_dir"])
+        command = cwd_wrap_command(command, final_kwargs["remote_working_dir"])
     if final_kwargs["use_shell"]:
         command = shell_wrap_command(command)
     if final_kwargs["use_sudo"]:

--- a/threadbare/operations.py
+++ b/threadbare/operations.py
@@ -59,6 +59,20 @@ class NetworkError(BaseException):
         return new_error + space + original_error
 
 
+def pem_key():
+    """returns the first private key found in a list of common private keys.
+    if none of the keys exist, the default (first) key will be returned."""
+    id_list = ["id_rsa", "id_dsa", "identity", "id_ecdsa"]
+    id_list = [os.path.expanduser("~/.ssh/" + idstr) for idstr in id_list]
+    for id_path in id_list:
+        if os.path.isfile(id_path):
+            return id_path
+        LOG.debug("key not found: %s" % id_path)
+
+    default = id_list[0]
+    return default
+
+
 def handle(base_kwargs, kwargs):
     """handles the merging of the base set of function keyword arguments and their possible overrides.
     `base_kwargs` is a map of the function's keyword arguments and their defaults.
@@ -119,9 +133,9 @@ def _ssh_client(**kwargs):
         # current user. sensible default but probably not what you want
         "user": getpass.getuser(),
         "host_string": None,
-        # TODO: parallel-ssh and fabric both look for the same ~4 possible keys and
-        # use the first one they find. implement that behaviour
-        "key_filename": os.path.expanduser("~/.ssh/id_rsa"),
+        # looks for the same ~4 possible keys as Fabric and ParallelSSH.
+        # uses the first one it finds or the most common if none found.
+        "key_filename": pem_key(),
         "port": 22,
     }
     global_kwargs, user_kwargs, final_kwargs = handle(base_kwargs, kwargs)

--- a/threadbare/operations.py
+++ b/threadbare/operations.py
@@ -32,7 +32,7 @@ class SSHClient(PSSHClient):
 
 class NetworkError(BaseException):
     """generic 'died while doing something ssh-related' catch-all exception class.
-    calling str() on this exception will return the results on calling str() on the
+    calling str() on this exception will return the results of calling str() on the
     wrapped exception."""
 
     def __init__(self, wrapped_exception_inst):
@@ -40,8 +40,8 @@ class NetworkError(BaseException):
 
     def __str__(self):
         # we have the opportunity here to tweak the error messages to make them
-        # similar with their equivalents in Fabric.
-        # original error messages are still available via `str(exinst.wrapped)`
+        # similar to their equivalents in Fabric.
+        # original error messages are still available via `str(excinst.wrapped)`
         space = " "
         custom_error_prefixes = {
             # builder: https://github.com/elifesciences/builder/blob/master/src/buildercore/core.py#L345-L347
@@ -60,6 +60,20 @@ class NetworkError(BaseException):
 
 
 def handle(base_kwargs, kwargs):
+    """handles the merging of the base set of function keyword arguments and their possible overrides.
+    `base_kwargs` is a map of the function's keyword arguments and their defaults.
+    `kwargs` are the keyword arguments used when executing the function.
+
+    the keys from `base_kwargs` are used to determine which keys to extract from the `kwargs` and any
+    global settings.
+
+    returns a triple of (`global_kwargs`, `user_kwargs`, `final_kwargs`) where
+    `global_kwargs` is the subset of keyword arguments extracted from `state.env`,
+    `user_kwargs` is the subset of keyword arguments extracted from the given kwargs and
+    `final_kwargs` is the result of merging `base_kwargs` <- `global_kwargs` <- `user_kwargs`
+
+    'user' keyword arguments that are explicitly passed in take precedence over all others and
+    'global' keyword arguments take precedence over the function's defaults kwargs."""
     key_list = base_kwargs.keys()
     global_kwargs = subdict(state.ENV, key_list)
     user_kwargs = subdict(kwargs, key_list)
@@ -105,6 +119,8 @@ def _ssh_client(**kwargs):
         # current user. sensible default but probably not what you want
         "user": getpass.getuser(),
         "host_string": None,
+        # TODO: parallel-ssh and fabric both look for the same ~4 possible keys and
+        # use the first one they find. implement that behaviour
         "key_filename": os.path.expanduser("~/.ssh/id_rsa"),
         "port": 22,
     }
@@ -121,7 +137,7 @@ def _ssh_client(**kwargs):
     client_key = subdict(final_kwargs, ["user", "host", "pkey", "port", "timeout"])
     client_key = tuple(sorted(client_key.items()))
 
-    # otherwise, check to see if a previous client is available
+    # otherwise, check to see if a previous client is available for this host
     client_map = env.get(client_map_key, {})
     if client_key in client_map:
         return client_map[client_key]
@@ -171,7 +187,7 @@ def _execute(command, user, key_filename, host_string, port, use_pty, timeout):
         }
     except BaseException as ex:
         # *probably* a network error:
-        # https://github.com/ParallelSSH/parallel-ssh/blob/master/pssh/exceptions.py
+        # - https://github.com/ParallelSSH/parallel-ssh/blob/master/pssh/exceptions.py
         raise NetworkError(ex)
 
 
@@ -209,7 +225,7 @@ def remote(command, **kwargs):
 
     # Fabric function signature for `run`
     # shell=True # done
-    # pty=True   # mutually exclusive with combine_stderr. not sure what Fabric/Paramiko is doing here
+    # pty=True   # mutually exclusive with `combine_stderr` in pssh. not sure how Fabric/Paramiko is doing it
     # combine_stderr=None # mutually exclusive with use_pty. 'True' in global env.
     # quiet=False, # done
     # warn_only=False # done
@@ -335,6 +351,13 @@ def remote_file_exists(path, **kwargs):
     # $ echo $foo
     # /usr/*/share
 
+    # TODO: revisit
+    # update 2020/01: it does work, I just had no "/usr/[anything]/share" directories.
+    # this works for me:
+    #   foo=$(echo /\*/share/)
+    #   echo $foo
+    #   /usr/share/
+
     base_kwargs = {
         "use_sudo": False,
     }
@@ -350,6 +373,7 @@ def remote_file_exists(path, **kwargs):
 
 # https://github.com/mathiasertl/fabric/blob/master/fabric/operations.py#L1157
 def local(command, **kwargs):
+    "preprocesses given `command` and options before executing it locally using Python's `subprocess.Popen`"
     base_kwargs = {
         "use_shell": True,
         "combine_stderr": True,
@@ -438,16 +462,16 @@ def local(command, **kwargs):
 
 
 def single_command(cmd_list):
-    """given a list of commands to run, returns a single command
-    `remote` and `local` are expected to do any escaping as necessary"""
+    "given a list of commands to run, returns a single command."
+    # `remote` and `local` will do any escaping as necessary
     if cmd_list in [None, []]:
         return None
     return " && ".join(map(str, cmd_list))
 
 
 def prompt(msg):
-    """issues a prompt for input. 
-    raises a PromptedException if `abort_on_prompts` in `state.ENV` is `True` or executing within 
+    """issues a prompt for input.
+    raises a `PromptedException` if `abort_on_prompts` in `state.ENV` is `True` or executing within
     another process using `execute.parallel` where input can't be supplied.
     if `abort_exception` is set in `state.ENV`, then that exception is raised instead"""
     if state.ENV.get("abort_on_prompts", False):

--- a/threadbare/state.py
+++ b/threadbare/state.py
@@ -40,7 +40,7 @@ def read_write(d):
 
 def initial_state():
     """returns a new, empty, locked, LockableDict instance that is used as the initial `state.ENV` value.
-    
+
     if you are thinking "it would be really convenient if 'some_setting' was 'some_value' by default",
     see `set_defaults`."""
     new_env = LockableDict()
@@ -124,7 +124,7 @@ def settings(**kwargs):
 
         DEPTH -= 1
 
-        # we're leaving the top-most context decorator
-        # ensure state dictionary is marked as read-only
         if DEPTH == 0:
+            # we're leaving the top-most context decorator
+            # ensure state dictionary is marked as read-only
             read_only(state)

--- a/threadbare/state.py
+++ b/threadbare/state.py
@@ -4,7 +4,7 @@ import contextlib
 CLEANUP_KEY = "_cleanup"
 
 
-class LockableDict(dict):
+class FreezeableDict(dict):
     def __init__(self, *args, **kwargs):
         dict.__init__(self, *args, **kwargs)
         self.read_only = False
@@ -39,11 +39,11 @@ def read_write(d):
 
 
 def initial_state():
-    """returns a new, empty, locked, LockableDict instance that is used as the initial `state.ENV` value.
+    """returns a new, empty, locked, FreezeableDict instance that is used as the initial `state.ENV` value.
 
     if you are thinking "it would be really convenient if 'some_setting' was 'some_value' by default",
     see `set_defaults`."""
-    new_env = LockableDict()
+    new_env = FreezeableDict()
     read_only(new_env)
     return new_env
 
@@ -55,7 +55,7 @@ DEPTH = 0  # used to determine how deeply nested we are
 
 def set_defaults(defaults_dict=None):
     """re-initialises the `state.ENV` dictionary with the given defaults.
-    with no arguments, the global state will be reverted to it's initial state (an empty LockableDict).
+    with no arguments, the global state will be reverted to it's initial state (an empty FreezeableDict).
 
     use `state.set_defaults` BEFORE using ANY other `state.*` functions are called."""
     global ENV, DEPTH
@@ -63,7 +63,7 @@ def set_defaults(defaults_dict=None):
         msg = "refusing to set initial `threadbare.state.ENV` state within a `threadbare.state.settings` context manager."
         raise EnvironmentError(msg)
 
-    new_env = LockableDict()
+    new_env = FreezeableDict()
     new_env.update(defaults_dict or {})
     read_only(new_env)
     ENV = new_env
@@ -103,7 +103,7 @@ def settings(**kwargs):
     # another approach would be to relax guarantees that the environment is completely reverted
 
     # call `read_write` here as `deepcopy` copies across attributes (like `read_only`) and
-    # then values using `__setitem__`, causing errors in LockableDict when 'set_defaults' used
+    # then values using `__setitem__`, causing errors in FreezeableDict when 'set_defaults' used
     read_write(state)
 
     original_values = copy.deepcopy(state)

--- a/tox.ini
+++ b/tox.ini
@@ -18,5 +18,5 @@ deps =
     pytest-cov
 envlist = PYTHONPATH=threadbare/
 commands =
-    python -m pytest tests/ -vv --cov=threadbare/ --cov-fail-under 75
+    python -m pytest tests/ -vv --cov=threadbare/
 


### PR DESCRIPTION
This is a branch to do any final tasks before a 1.0 version of Threadbare is released. 

Version 1.0 of Threadbare will be considered stable, suitable for use in Builder and suitable for releasing on pypi.

This branch should incorporate any feedback from integration testing with Builder, especially bugs.

This branch is *not* the place for nice-to-haves. Add those to the `TODO bucket` section of the TODO.md file.

Builder with a Threadbare backend is [currently green](https://github.com/elifesciences/builder/pull/586). There is also support for switching back to a Fabric/Paramiko backend, [also green](https://github.com/elifesciences/builder/pull/593).

cc @giorgiosironi 
