### PR TITLE
transfer-protocol, default backend reverted to sftp.

### DIFF
--- a/example.py
+++ b/example.py
@@ -41,7 +41,12 @@ It's assumed the dummy sshd server is running and that the host is `localhost`.
 assert (HOST and PORT and USER) and common.isint(PORT), _help_text
 
 test_settings = partial(
-    settings, user=USER, port=int(PORT), host_string=HOST, key_filename=KEY
+    settings,
+    user=USER,
+    port=int(PORT),
+    host_string=HOST,
+    key_filename=KEY,
+    transfer_protocol="scp",
 )
 
 

--- a/lint.sh
+++ b/lint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 source venv/bin/activate
 

--- a/threadbare/operations.py
+++ b/threadbare/operations.py
@@ -558,7 +558,10 @@ def _transfer_fn(client, direction, **kwargs):
         # sftp is *exceptionally* slow so SCP is used by default.
         # paramiko's own Python implementation is faster than native SFTP but slower than SCP:
         # - https://github.com/ParallelSSH/parallel-ssh/issues/177
-        "transfer_protocol": "scp",
+        # however, SCP is buggy and may randomly hang or complete without uploading anything.
+        # take slow and reliable over fast and buggy
+        # "transfer_protocol": "scp",
+        "transfer_protocol": "sftp",
     }
     global_kwargs, user_kwargs, final_kwargs = handle(base_kwargs, kwargs)
 


### PR DESCRIPTION
scp has proven itself to be buggy and unreliable outside of threadbare testing