### PR TITLE
execute.execute now re-raises unhandled exceptions in parallel operations

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -10,5 +10,5 @@ find tests/ -name '*.py[c|~]' -delete
 find threadbare/ -regex "\(.*__pycache__.*\|*.py[co]\)" -delete
 find tests/ -regex "\(.*__pycache__.*\|*.py[co]\)" -delete
 
-pyflakes threadbare/ tests/ example.py
-black threadbare/ tests/ example.py --target-version py27
+pyflakes example.py threadbare/ tests/
+black example.py threadbare/ tests/ --target-version py27

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -5,10 +5,10 @@
 set -e
 
 echo "(destroying any venv)"
-rm -rf venv/
+#rm -rf venv/
 
 # creates a venv and test dependencies
-. install.sh -dev
+#. install.sh -dev
 
 ./tests-remote/sshd-server.sh &
 sleep 1 # it's possible to hit pytest before sshd-server has finished

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -5,10 +5,10 @@
 set -e
 
 echo "(destroying any venv)"
-#rm -rf venv/
+rm -rf venv/
 
 # creates a venv and test dependencies
-#. install.sh -dev
+. install.sh -dev
 
 ./tests-remote/sshd-server.sh &
 sleep 1 # it's possible to hit pytest before sshd-server has finished

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,7 @@ dev=${1:-""}
 if [ "$dev" = "dev" ]; then
     shift # pop the first arg off
     source venv/bin/activate
-    if [ -z "$1" ]; then
+    if [ -z "$@" ]; then
         # no further args passed to test script
         # run with coverage and reporting enabled
         PYTHONPATH=threadbare/ python -m pytest \
@@ -24,7 +24,6 @@ if [ "$dev" = "dev" ]; then
     else
         # running tests adhoc, skip coverage reporting
         PYTHONPATH=threadbare/ python -m pytest \
-            tests/ \
             -vv \
             --cov=threadbare/ \
             --cov-report html --cov-report term \

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -259,8 +259,8 @@ def test_parallel_worker_exceptions__raise_errors():
 
     with pytest.raises(EnvironmentError) as e:
         execute.execute(workerfn)
-        assert isinstance(e, EnvironmentError)
-        assert str(e) == exc_msg
+        expected = exc_msg
+        assert expected == str(e)
 
 
 def test_parallel_worker_exceptions__swallow_errors():
@@ -330,7 +330,7 @@ def test_parallel_with_prompts_custom__raise_errors():
 
 
 def test_parallel_with_prompts_custom__swallow_errors():
-    "prompts issued while executing a worker function in parallel with `abort_exception` return a custom exception"
+    "prompts issued while executing a worker function in parallel with `abort_exception` set returns the custom exception"
 
     @execute.parallel
     def workerfn():
@@ -338,14 +338,13 @@ def test_parallel_with_prompts_custom__swallow_errors():
 
     with settings(abort_exception=ValueError):
         results = execute.execute(workerfn, raise_unhandled_errors=False)
-        expected = str(ValueError("prompted with: gimmie"))
+        expected = "prompted with: gimmie"
         assert expected == str(results[0])
 
 
 def test_execute_with_prompts_override__raise_errors():
-    """prompts issued while executing a worker function in parallel that has set
-    their `abort_on_prompts` to `False` will get the unsupported `EOFError` raised.
-    If `raise_unhandled_errors` is set to `True` (default), the `EOFError` will be re-thrown."""
+    """prompts issued while executing a worker function in parallel with `abort_on_prompts` set to `False` will get the unsupported `EOFError` raised.
+    When `raise_unhandled_errors` is set to `True` (default) the `EOFError` will be re-thrown."""
 
     @execute.parallel
     def workerfn():
@@ -359,9 +358,8 @@ def test_execute_with_prompts_override__raise_errors():
 
 
 def test_execute_with_prompts_override__swallow_errors():
-    """prompts issued while executing a worker function in parallel that has set
-    their `abort_on_prompts` to `False` will get the unsupported `EOFError` raised.
-    If `raise_unhandled_errors` is set to `False`, the `EOFError` is available in the results."""
+    """prompts issued while executing a worker function in parallel with `abort_on_prompts` set to `False` will get the unsupported `EOFError` raised.
+    When `raise_unhandled_errors` is set to `False` the `EOFError` is available in the results."""
 
     @execute.parallel
     def workerfn():

--- a/threadbare/execute.py
+++ b/threadbare/execute.py
@@ -167,7 +167,7 @@ def _serial_execution(func, param_key, param_values):
     return result_list
 
 
-def execute(func, param_key=None, param_values=None):
+def execute(func, param_key=None, param_values=None, raise_unhandled_errors=True):
     """inspects a given function and then executes it either serially or in another process using Python's `multiprocessing` module.
     `param` and `param_list` control the number of processes spawned and the name of the parameter passed to the function.
 
@@ -207,12 +207,25 @@ def execute(func, param_key=None, param_values=None):
         )
 
     if hasattr(func, "parallel") and func.parallel:
-        result_list = _parallel_execution(state.ENV, func, param_key, param_values)
-        return [result["result"] for result in result_list]
+        result_payload_list = _parallel_execution(
+            state.ENV, func, param_key, param_values
+        )
+        response = []
+        for result_payload in result_payload_list:
+            if (
+                isinstance(result_payload["result"], BaseException)
+                and raise_unhandled_errors
+            ):
+                unhandled_error = result_payload["result"]
+                raise unhandled_error
+            response.append(result_payload["result"])
+        return response
     return _serial_execution(func, param_key, param_values)
 
 
-def execute_with_hosts(func, hosts=None, line_template=None):
+def execute_with_hosts(
+    func, hosts=None, line_template=None, raise_unhandled_errors=True
+):
     """convenience wrapper around `execute`. calls `execute` on given `func` for each host in `hosts`.
     The host is available within the worker function's `env` as `host_string`."""
     host_list = hosts or state.ENV.get("hosts") or []
@@ -229,6 +242,11 @@ def execute_with_hosts(func, hosts=None, line_template=None):
     default = "{host:15} {pipe}: {line}\n"
     line_template = line_template or state.ENV.get("line_template") or default
     with state.settings(line_template=line_template):
-        results = execute(func, param_key="host_string", param_values=host_list)
+        results = execute(
+            func,
+            param_key="host_string",
+            param_values=host_list,
+            raise_unhandled_errors=raise_unhandled_errors,
+        )
     # results are ordered so we can do this
     return dict(zip(host_list, results))  # {'192.168.0.1': [], '192.169.0.3': []}

--- a/threadbare/execute.py
+++ b/threadbare/execute.py
@@ -180,7 +180,9 @@ def execute(func, param_key=None, param_values=None, raise_unhandled_errors=True
     `param` and `param_list` are optional, but if one is specified then so must the other.
 
     parent process blocks until all child processes have completed.
-    returns a map of execution data with the return values of the individual executions available under 'result'"""
+    returns a map of execution data with the return values of the individual executions available under 'result'.
+
+    when `raise_unhandled_errors` is `True` (default), the first result that is an exception will be re-raised."""
 
     # in Fabric, `execute` is a guard-type function that ensures the function and the function's environment is
     # correct before passing it to `_execute` that does the actual magic.


### PR DESCRIPTION
execute.execute now re-raises unhandled exceptions in parallel operations
the option 'raise_unhandled_errors' can be set to 'True' to disable this new behaviour.
this fixes a deviation in behaviour from Fabric.

- [x] review