### PR TITLE
operations, adds 'display_prefix' option

### DIFF
--- a/test-examples.sh
+++ b/test-examples.sh
@@ -7,7 +7,7 @@ temp_dir="/tmp/sshd-dummy"
 # see ./tests-remote/sshd-server.sh
 # and ./tests-remote/ssh-client.sh
 echo "---------------"
-echo "looking for dummy ssh server"
+echo "looking for dummy ssh server, see ./tests-remote/sshd-server.sh"
 die=false
 exec 6<>/dev/tcp/localhost/8462 || {
     die=true

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -623,13 +623,13 @@ def test_formatted_output_display_running():
     "the 'print running' function obeys formatting rules"
     cases = [
         # command, expected output, more settings
-        ("ls -l", "1.2.3.4 run: ls -l\n", {"host_string": "1.2.3.4"}),
+        ("ls -l", "[1.2.3.4] run: ls -l\n", {"host_string": "1.2.3.4"}),
         ("ls -l", "ls -l\n", {"host_string": "1.2.3.4", "display_prefix": False}),
         ("ls -l", "", {"host_string": "1.2.3.4", "quiet": True}),
         (
             "ls -l",
-            "[1.2.3.4] (run) ls -l\n",
-            {"host_string": "1.2.3.4", "line_template": "[{host}] ({pipe}) {line}\n"},
+            "<1.2.3.4> (run) ls -l\n",
+            {"host_string": "1.2.3.4", "line_template": "<{host}> ({pipe}) {line}\n"},
         ),
     ]
     for command, expected, settings in cases:

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -619,7 +619,24 @@ def test_formatted_output_display_prefix():
 
 
 def test_formatted_output_display_running():
-    pass
+    cases = [
+        # command, expected output, more settings
+        ("ls -l", "1.2.3.4 run: ls -l\n", {"host_string": "1.2.3.4"}),
+        ("ls -l", "ls -l\n", {"host_string": "1.2.3.4", "display_prefix": False}),
+        ("ls -l", "", {"host_string": "1.2.3.4", "quiet": True}),
+        (
+            "ls -l",
+            "[1.2.3.4] (run) ls -l\n",
+            {"host_string": "1.2.3.4", "line_template": "[{host}] ({pipe}) {line}\n"},
+        ),
+    ]
+    for command, expected, settings in cases:
+        strbuffer = StringIO()
+        with state.settings(**settings):
+            operations._print_running(
+                command, strbuffer, display_running=True, **settings
+            )
+        assert expected == strbuffer.getvalue()
 
 
 def test_formatted_output_display_aborts():

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -24,13 +24,14 @@ PEM = "/home/testuser/.ssh/id_rsa"
 
 
 def test_hide():
-    "`hide` in threadbare just sets quiet=True. It's much more fine grained in fabric."
+    """`hide` in threadbare just sets quiet=True. It's much more fine grained in fabric.
+    see `test_local_quiet_param` and `test_remote_quiet_param`"""
     with operations.hide():
         assert state.ENV == {"quiet": True}
 
 
 def test_hide_w_args():
-    "`hide` in threadbare supports arguments for the types of things to be hidden, all of which are ignored"
+    "`hide` in threadbare supports arguments for the types of things to be hidden, all of which are ignored (for now)"
     with operations.hide("egg"):
         assert state.ENV == {"quiet": True}
 
@@ -534,6 +535,7 @@ def test_single_command():
         assert expected == actual, "failed case. %r != %r" % (expected, actual)
 
 
+# todo: test_remote_quiet_param
 def test_local_quiet_param():
     "when quiet=True, nothing is sent to stdout or stderr"
     cmd = lambda: operations.local(
@@ -591,6 +593,37 @@ def test_formatted_output_unicode():
     with state.settings(line_template=line_template):
         result = operations._print_line(StringIO(), unicode_point)
         assert expected_stdout == result
+
+
+def test_formatted_output_display_prefix():
+    "a line of output can have it's prefix stripped"
+    cases = [
+        # (line template, what is printed to given pipe (stringbuffer, stdout, stderr, etc), what is returned to user)
+        ("{line}", "hello, world", "hello, world"),
+        ("{host} {pipe}: {line}", "hello, world", "hello, world"),
+        ("{host} {pipe}: ", "1.2.3.4 out: ", "hello, world"),
+        ("{line} {host}", "hello, world 1.2.3.4", "hello, world"),
+        ("{line} {line}", "hello, world hello, world", "hello, world"),
+    ]
+    for given_template, expected_stdout, expected_return in cases:
+        strbuffer = StringIO()
+        settings = {
+            "host_string": "1.2.3.4",
+            "line_template": given_template,
+            "display_prefix": False,
+        }
+        with state.settings(**settings):
+            result = operations._print_line(strbuffer, "hello, world")
+            assert expected_stdout == strbuffer.getvalue()
+            assert expected_return == result
+
+
+def test_formatted_output_display_running():
+    pass
+
+
+def test_formatted_output_display_aborts():
+    pass
 
 
 def test_rsync_upload_command():

--- a/threadbare/execute.py
+++ b/threadbare/execute.py
@@ -224,9 +224,7 @@ def execute(func, param_key=None, param_values=None, raise_unhandled_errors=True
     return _serial_execution(func, param_key, param_values)
 
 
-def execute_with_hosts(
-    func, hosts=None, line_template=None, raise_unhandled_errors=True
-):
+def execute_with_hosts(func, hosts=None, raise_unhandled_errors=True):
     """convenience wrapper around `execute`. calls `execute` on given `func` for each host in `hosts`.
     The host is available within the worker function's `env` as `host_string`."""
     host_list = hosts or state.ENV.get("hosts") or []
@@ -240,14 +238,11 @@ def execute_with_hosts(
     # - https://github.com/elifesciences/builder/blob/master/src/buildercore/core.py#L386
     # it says 'for informational purposes only' and nothing we use depends on it, so I'm disabling for now
     # env['all_hosts'] = env['hosts']
-    default = "{host:15} {pipe}: {line}\n"  # todo: revisit this
-    line_template = line_template or state.ENV.get("line_template") or default
-    with state.settings(line_template=line_template):
-        results = execute(
-            func,
-            param_key="host_string",
-            param_values=host_list,
-            raise_unhandled_errors=raise_unhandled_errors,
-        )
+    results = execute(
+        func,
+        param_key="host_string",
+        param_values=host_list,
+        raise_unhandled_errors=raise_unhandled_errors,
+    )
     # results are ordered so we can do this
     return dict(zip(host_list, results))  # {'192.168.0.1': [], '192.169.0.3': []}

--- a/threadbare/execute.py
+++ b/threadbare/execute.py
@@ -240,7 +240,7 @@ def execute_with_hosts(
     # - https://github.com/elifesciences/builder/blob/master/src/buildercore/core.py#L386
     # it says 'for informational purposes only' and nothing we use depends on it, so I'm disabling for now
     # env['all_hosts'] = env['hosts']
-    default = "{host:15} {pipe}: {line}\n"
+    default = "{host:15} {pipe}: {line}\n"  # todo: revisit this
     line_template = line_template or state.ENV.get("line_template") or default
     with state.settings(line_template=line_template):
         results = execute(

--- a/threadbare/operations.py
+++ b/threadbare/operations.py
@@ -147,7 +147,6 @@ def _ssh_default_settings():
         "use_sudo": False,
         "combine_stderr": True,
         "quiet": False,
-        
         "remote_working_dir": None,
         "timeout": None,
         "warn_only": False,  # https://github.com/mathiasertl/fabric/blob/master/fabric/state.py#L301-L305

--- a/threadbare/operations.py
+++ b/threadbare/operations.py
@@ -147,9 +147,7 @@ def _ssh_default_settings():
         "use_sudo": False,
         "combine_stderr": True,
         "quiet": False,
-        "discard_output": False,
-        # todo: duplicated content. this needs to defer to deeply nested `_print_line`
-        "line_template": "{line}\n",
+        
         "remote_working_dir": None,
         "timeout": None,
         "warn_only": False,  # https://github.com/mathiasertl/fabric/blob/master/fabric/state.py#L301-L305
@@ -246,7 +244,7 @@ def _print_line(output_pipe, line, **kwargs):
     base_kwargs = {
         "discard_output": False,
         "quiet": False,
-        "line_template": "{host} {pipe}: {line}\n",  # "1.2.3.4  err: Foo not found\n"
+        "line_template": "[{host}] {pipe}: {line}\n",  # "1.2.3.4  err: Foo not found\n"
         "display_prefix": True,  # strips everything in `line_template` before "{line}"
         "custom_pipe": None,
     }
@@ -370,7 +368,7 @@ def remote(command, **kwargs):
 
     # parameters we're interested in and their default values
     base_kwargs = _ssh_default_settings()
-    base_kwargs.update({"display_running": True})
+    base_kwargs.update({"display_running": True, "discard_output": False})
     global_kwargs, user_kwargs, final_kwargs = handle(base_kwargs, kwargs)
 
     # wrap the command up

--- a/threadbare/state.py
+++ b/threadbare/state.py
@@ -55,9 +55,9 @@ DEPTH = 0  # used to determine how deeply nested we are
 
 def set_defaults(defaults_dict=None):
     """re-initialises the `state.ENV` dictionary with the given defaults.
-    with no arguments, the global state will be reverted to it's initial state (an empty FreezeableDict).
+    With no arguments the global state will be reverted to it's initial state (an empty FreezeableDict).
 
-    use `state.set_defaults` BEFORE using ANY other `state.*` functions are called."""
+    Use `state.set_defaults` BEFORE using ANY other `state.*` functions are called."""
     global ENV, DEPTH
     if DEPTH != 0:
         msg = "refusing to set initial `threadbare.state.ENV` state within a `threadbare.state.settings` context manager."


### PR DESCRIPTION
adds output options to threadbare that fabric has and that are being used by builder

- [x] `fabric.state.output` 'prefix' -> `display_prefix`
- [x] `fabric.state.output` 'running' -> `display_running`
- [x] `fabric.state.output` 'aborts' -> `display_aborts`
- [x] review