### PR TITLE
fixes support for rsa algorithims in newer versions of sshd

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ with settings(host_string='my.server', warn_only=True):
 
 Run the [test suite](./test.sh) with `./test.sh`
 
-Individual tests can be run with `./test.sh -k test_fn_name`
+Individual tests can be run with `./test.sh example.py::test_fn_name`
 
 ## remote tests
 

--- a/test-examples.sh
+++ b/test-examples.sh
@@ -28,4 +28,10 @@ export THREADBARE_TEST_PORT=8462
 export THREADBARE_TEST_USER="$USER"
 export THREADBARE_TEST_PUBKEY="$temp_dir/.ssh/dummy_user_key"
 source venv/bin/activate
-pytest example.py -vv "$@"
+
+args="$*"
+if [ -z "$args" ]; then
+    args="example.py"
+fi
+
+pytest -vv "$args"

--- a/tests-remote/sshd-server.sh
+++ b/tests-remote/sshd-server.sh
@@ -55,6 +55,7 @@ fi
 2>&1 $(which sshd) \
     -D \
     -e \
+    -q \
     -f "$SCRIPT_PATH/$sshd_config" \
     -h "$temp_dir/.ssh/dummy_host_key" \
     | grep -v "Attempt to write login records by non-root user (aborting)"

--- a/tests-remote/sshd-server.sh
+++ b/tests-remote/sshd-server.sh
@@ -35,12 +35,21 @@ cat "$temp_dir/.ssh/dummy_user_key.pub" > "$temp_dir/.ssh/authorized_keys"
 # note! permissions checking has been disabled in sshd_config
 # see `StrictModes`
 
-# -D -- do NOT become a daemon
-# -e -- write debug log to stderr
-# -q -- nothing is sent to the system log. disable to see sshd server output
-# -f -- path to custom sshd config
-# -h -- host key file, just a simple private key
-# for more output, set "LogLevel DEBUG" in `sshd_config`. default is INFO
-$(which sshd) -D -e -q -f "$SCRIPT_PATH/sshd_config" -h "$temp_dir/.ssh/dummy_host_key"
+# 2>&1 -- redirect stderr into stdout. this is so we can filter noise from sshd output when -q is off.
+# -D   -- do NOT become a daemon
+# -e   -- write debug log to stderr
+# -q   -- nothing is sent to the system log. disable to see sshd server output
+#         for more output, set "LogLevel DEBUG" in `sshd_config`. default is INFO level.
+# -f   -- path to custom sshd config
+# -h   -- host key file, just a simple private key
+# | grep -v ... -- exclude noise from sshd output when -q is off
+
+2>&1 $(which sshd) \
+    -D \
+    -e \
+    -q \
+    -f "$SCRIPT_PATH/sshd_config" \
+    -h "$temp_dir/.ssh/dummy_host_key" \
+    | grep -v "Attempt to write login records by non-root user (aborting)"
 
 # at this point you can run the ./ssh-client.sh script to check the server is running properly

--- a/tests-remote/sshd-server.sh
+++ b/tests-remote/sshd-server.sh
@@ -32,6 +32,14 @@ trap 'cleanup' SIGINT
 # allow the dummy user to login to the dummy server
 cat "$temp_dir/.ssh/dummy_user_key.pub" > "$temp_dir/.ssh/authorized_keys"
 
+# OpenSSH on Ubuntu 20.04 is (currently) 8.2
+# OpenSSH on my development machine is 9.2
+# new configuration options in old configuration files will cause sshd to exit and the tests to fail.
+sshd_config="sshd_config"
+if ssh -V 2>&1 | grep 'OpenSSH_9\.'; then
+    sshd_config="sshd_config_9"
+fi
+
 # note! permissions checking has been disabled in sshd_config
 # see `StrictModes`
 
@@ -47,7 +55,7 @@ cat "$temp_dir/.ssh/dummy_user_key.pub" > "$temp_dir/.ssh/authorized_keys"
 2>&1 $(which sshd) \
     -D \
     -e \
-    -f "$SCRIPT_PATH/sshd_config" \
+    -f "$SCRIPT_PATH/$sshd_config" \
     -h "$temp_dir/.ssh/dummy_host_key" \
     | grep -v "Attempt to write login records by non-root user (aborting)"
 

--- a/tests-remote/sshd-server.sh
+++ b/tests-remote/sshd-server.sh
@@ -47,7 +47,6 @@ cat "$temp_dir/.ssh/dummy_user_key.pub" > "$temp_dir/.ssh/authorized_keys"
 2>&1 $(which sshd) \
     -D \
     -e \
-    -q \
     -f "$SCRIPT_PATH/sshd_config" \
     -h "$temp_dir/.ssh/dummy_host_key" \
     | grep -v "Attempt to write login records by non-root user (aborting)"

--- a/tests-remote/sshd_config
+++ b/tests-remote/sshd_config
@@ -1,30 +1,20 @@
-#	$OpenBSD: sshd_config,v 1.104 2021/07/02 05:11:21 dtucker Exp $
+#	$OpenBSD: sshd_config,v 1.102 2018/02/16 02:32:40 djm Exp $
 
 # This is the sshd server system-wide configuration file.  See
 # sshd_config(5) for more information.
 
-# This sshd was compiled with PATH=/usr/local/sbin:/usr/local/bin:/usr/bin
-
-# The strategy used for options in the default sshd_config shipped with
-# OpenSSH is to specify options with their default value where
-# possible, but leave them commented.  Uncommented options override the
-# default value.
-
 Port 8462
+
+# don't ever set this in a serious environment.
+# this allows us to bypass some permissions requirements.
+StrictModes no
 
 # Logging
 #LogLevel DEBUG
 LogLevel INFO
 
 # Authentication:
-
-LoginGraceTime 5 # seconds
 PermitRootLogin no
-## lsh-0: don't ever set this in a serious environment.
-## this allows us to bypass some permissions requirements.
-StrictModes no
-MaxAuthTries 2
-
 PubkeyAuthentication yes
 
 # The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
@@ -43,18 +33,12 @@ PasswordAuthentication no
 # Change to no to disable s/key passwords
 ChallengeResponseAuthentication no
 
-UsePAM no
-
 PidFile /tmp/sshd-dummy/sshd.pid
 
 # override default of no subsystems
-## lsh-0: necessary for uploads and downloads
-## 'internal-sftp' or a path?
-##  - https://serverfault.com/questions/660160/openssh-difference-between-internal-sftp-and-sftp-server
-## it also means we can handily avoid hardcoding a path that differs between arch and ubuntu
+# necessary for uploads and downloads
+# 'internal-sftp' or a path?
+#  - https://serverfault.com/questions/660160/openssh-difference-between-internal-sftp-and-sftp-server
+# it also means we can handily avoid hardcoding a path that differs between arch and ubuntu
 #Subsystem sftp /usr/lib/ssh/sftp-server
 Subsystem sftp internal-sftp
-
-## lsh-0: the dummy key type we're generating (rsa) is no longer recommended.
-HostKeyAlgorithms +ssh-rsa
-PubkeyAcceptedAlgorithms +ssh-rsa

--- a/tests-remote/sshd_config
+++ b/tests-remote/sshd_config
@@ -17,10 +17,13 @@ Port 8462
 LogLevel INFO
 
 # Authentication:
+
+LoginGraceTime 5 # seconds
 PermitRootLogin no
 ## lsh-0: don't ever set this in a serious environment.
 ## this allows us to bypass some permissions requirements.
 StrictModes no
+MaxAuthTries 2
 
 PubkeyAuthentication yes
 

--- a/tests-remote/sshd_config
+++ b/tests-remote/sshd_config
@@ -1,13 +1,16 @@
-#	$OpenBSD: sshd_config,v 1.102 2018/02/16 02:32:40 djm Exp $
+#	$OpenBSD: sshd_config,v 1.104 2021/07/02 05:11:21 dtucker Exp $
 
 # This is the sshd server system-wide configuration file.  See
 # sshd_config(5) for more information.
 
-Port 8462
+# This sshd was compiled with PATH=/usr/local/sbin:/usr/local/bin:/usr/bin
 
-# don't ever set this in a serious environment.
-# this allows us to bypass some permissions requirements.
-StrictModes no
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+Port 8462
 
 # Logging
 #LogLevel DEBUG
@@ -15,6 +18,10 @@ LogLevel INFO
 
 # Authentication:
 PermitRootLogin no
+## lsh-0: don't ever set this in a serious environment.
+## this allows us to bypass some permissions requirements.
+StrictModes no
+
 PubkeyAuthentication yes
 
 # The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
@@ -33,12 +40,18 @@ PasswordAuthentication no
 # Change to no to disable s/key passwords
 ChallengeResponseAuthentication no
 
+UsePAM no
+
 PidFile /tmp/sshd-dummy/sshd.pid
 
 # override default of no subsystems
-# necessary for uploads and downloads
-# 'internal-sftp' or a path?
-#  - https://serverfault.com/questions/660160/openssh-difference-between-internal-sftp-and-sftp-server
-# it also means we can handily avoid hardcoding a path that differs between arch and ubuntu
+## lsh-0: necessary for uploads and downloads
+## 'internal-sftp' or a path?
+##  - https://serverfault.com/questions/660160/openssh-difference-between-internal-sftp-and-sftp-server
+## it also means we can handily avoid hardcoding a path that differs between arch and ubuntu
 #Subsystem sftp /usr/lib/ssh/sftp-server
 Subsystem sftp internal-sftp
+
+## lsh-0: the dummy key type we're generating (rsa) is no longer recommended.
+HostKeyAlgorithms +ssh-rsa
+PubkeyAcceptedAlgorithms +ssh-rsa

--- a/tests-remote/sshd_config_9
+++ b/tests-remote/sshd_config_9
@@ -1,0 +1,60 @@
+#	$OpenBSD: sshd_config,v 1.104 2021/07/02 05:11:21 dtucker Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/local/sbin:/usr/local/bin:/usr/bin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+Port 8462
+
+# Logging
+#LogLevel DEBUG
+LogLevel INFO
+
+# Authentication:
+
+LoginGraceTime 5 # seconds
+PermitRootLogin no
+## lsh-0: don't ever set this in a serious environment.
+## this allows us to bypass some permissions requirements.
+StrictModes no
+MaxAuthTries 2
+
+PubkeyAuthentication yes
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	/tmp/sshd-dummy/.ssh/authorized_keys
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+HostbasedAuthentication no
+
+# Don't read the user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication no
+
+# Change to no to disable s/key passwords
+ChallengeResponseAuthentication no
+
+UsePAM no
+
+PidFile /tmp/sshd-dummy/sshd.pid
+
+# override default of no subsystems
+## lsh-0: necessary for uploads and downloads
+## 'internal-sftp' or a path?
+##  - https://serverfault.com/questions/660160/openssh-difference-between-internal-sftp-and-sftp-server
+## it also means we can handily avoid hardcoding a path that differs between arch and ubuntu
+#Subsystem sftp /usr/lib/ssh/sftp-server
+Subsystem sftp internal-sftp
+
+## lsh-0: the dummy key type we're generating (rsa) is no longer recommended.
+HostKeyAlgorithms +ssh-rsa
+PubkeyAcceptedAlgorithms +ssh-rsa


### PR DESCRIPTION
test.sh, replaced running tests individually with -k in favour of the example.py::foo::bar syntax. sshd, sshd_config synced with a more recent version of the config.